### PR TITLE
💪🏾Configure `PublishApi` target

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -195,7 +195,7 @@ public class Build : EnhancedNukeBuild,
     ];
 
     public Target PublishApi => _ => _.Description("Publish image of the API")
-                                    .TryTriggeredBy<IPushNugetPackages>()
+                                    .DependsOn<IPushNugetPackages>()
                                     .After(Tests)
                                     .TryAfter<IPack>()
                                     .Consumes(this.Get<ICompile>().Compile)

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -196,6 +196,7 @@ public class Build : EnhancedNukeBuild,
 
     public Target PublishApi => _ => _.Description("Publish image of the API")
                                     .DependsOn<IPushNugetPackages>()
+                                    .TriggeredBy<IPushNugetPackages>()
                                     .After(Tests)
                                     .TryAfter<IPack>()
                                     .Consumes(this.Get<ICompile>().Compile)

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -194,9 +194,10 @@ public class Build : EnhancedNukeBuild,
                                   this.Get<IHaveGitHubRepository>().GitHubToken)
     ];
 
-    public Target PublishApi => _ => _.Inherit<IPack>()
-                                    .Description("Publish image of the API")
+    public Target PublishApi => _ => _.Description("Publish image of the API")
+                                    .TryTriggeredBy<IPushNugetPackages>()
                                     .After(Tests)
+                                    .TryAfter<IPack>()
                                     .Consumes(this.Get<ICompile>().Compile)
                                     .Produces(this.Get<IHaveArtifacts>().ArtifactsDirectory / "publish" / "*.tar.gz")
                                     .Executes(() =>


### PR DESCRIPTION
Configures PublishApi` target in order to automatically push OCI image when publishing nuget packages.