### PR TITLE
Stabilize apphost startup and API readiness

### DIFF
--- a/tests/Agenda.API.IntegrationTests/Fixtures/AgendaApplicationTestingBuilder.cs
+++ b/tests/Agenda.API.IntegrationTests/Fixtures/AgendaApplicationTestingBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,6 +24,7 @@ public class AgendaApplicationTestingBuilder : IAsyncLifetime
     /// Time to wait after which the application under test will be considered as "not started".
     /// </summary>
     private static readonly TimeSpan s_startStopTimeout = TimeSpan.FromSeconds(120);
+    private static readonly TimeSpan s_readinessProbeDelay = TimeSpan.FromMilliseconds(500);
     /// <summary>
     /// Time to wait after which building the infrastructure will be considered as failed.
     /// </summary>
@@ -56,9 +58,40 @@ public class AgendaApplicationTestingBuilder : IAsyncLifetime
         await _app.StartAsync(cancellationToken).WaitAsync(s_startStopTimeout, cancellationToken);
         await _app.WaitForResourcesAsync(cancellationToken: cancellationToken).WaitAsync(s_startStopTimeout, cancellationToken);
 
-        ApiClient = _app.CreateHttpClient(ApiResourceName);
+        ApiClient = _app.CreateHttpClient(ApiResourceName, endpointName: "http");
+        await WaitUntilApiIsReachableAsync(cancellationToken);
 
         return _app;
+    }
+
+    private async Task WaitUntilApiIsReachableAsync(CancellationToken cancellationToken)
+    {
+        Exception lastException = null;
+
+        using CancellationTokenSource timeoutCancellationTokenSource = new(s_startStopTimeout);
+        using CancellationTokenSource linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellationTokenSource.Token);
+
+        while (!linkedCancellationTokenSource.IsCancellationRequested)
+        {
+            try
+            {
+                using HttpRequestMessage request = new(HttpMethod.Get, "/health");
+                using HttpResponseMessage response = await ApiClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, linkedCancellationTokenSource.Token);
+
+                if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return;
+                }
+            }
+            catch (Exception exception) when (exception is HttpRequestException or TaskCanceledException)
+            {
+                lastException = exception;
+            }
+
+            await Task.Delay(s_readinessProbeDelay, linkedCancellationTokenSource.Token);
+        }
+
+        throw new TimeoutException("The API endpoint did not become reachable before the startup timeout elapsed.", lastException);
     }
 
 

--- a/tests/Agenda.API.IntegrationTests/Fixtures/DistributedApplicationTestingBuilderFactory.cs
+++ b/tests/Agenda.API.IntegrationTests/Fixtures/DistributedApplicationTestingBuilderFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Aspire.Hosting.ApplicationModel;
@@ -28,6 +29,7 @@ namespace Agenda.API.IntegrationTests.Fixtures;
 public static class DistributedApplicationTestingBuilderFactory
 {
     private static readonly TimeSpan s_defaultTimeout = 30.Seconds();
+    private static int s_httpsCertificateChecked;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DistributedApplicationTestingBuilderFactory"/> class.
@@ -37,6 +39,8 @@ public static class DistributedApplicationTestingBuilderFactory
     /// <returns></returns>
     public static async Task<AgendaApplicationTestingBuilder> CreateBuilderAsync(ITestOutputHelper outputHelper = null, CancellationToken cancellationToken = default)
     {
+        EnsureDeveloperHttpsCertificate();
+
         string previousRunningIntegrationTestsValue = Environment.GetEnvironmentVariable("RunningIntegrationTests");
         Environment.SetEnvironmentVariable("RunningIntegrationTests", bool.TrueString);
         IDistributedApplicationTestingBuilder builder = await DistributedApplicationTestingBuilder.CreateAsync<Agenda_AppHost>(cancellationToken);
@@ -68,5 +72,47 @@ public static class DistributedApplicationTestingBuilderFactory
                                     });
 
         return new AgendaApplicationTestingBuilder(builder, previousRunningIntegrationTestsValue);
+    }
+
+    private static void EnsureDeveloperHttpsCertificate()
+    {
+        if (Interlocked.Exchange(ref s_httpsCertificateChecked, 1) == 1)
+        {
+            return;
+        }
+
+        ProcessStartInfo checkCertificateStartInfo = new("dotnet", "dev-certs https --check")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using Process checkCertificateProcess = Process.Start(checkCertificateStartInfo);
+        checkCertificateProcess?.WaitForExit();
+
+        if (checkCertificateProcess is not null && checkCertificateProcess.ExitCode == 0)
+        {
+            return;
+        }
+
+        ProcessStartInfo createCertificateStartInfo = new("dotnet", "dev-certs https")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using Process createCertificateProcess = Process.Start(createCertificateStartInfo);
+        createCertificateProcess?.WaitForExit();
+
+        if (createCertificateProcess is null || createCertificateProcess.ExitCode != 0)
+        {
+            string errorOutput = createCertificateProcess?.StandardError.ReadToEnd() ?? string.Empty;
+            string standardOutput = createCertificateProcess?.StandardOutput.ReadToEnd() ?? string.Empty;
+            throw new InvalidOperationException($"Unable to create ASP.NET Core developer HTTPS certificate. stdout='{standardOutput}' stderr='{errorOutput}'");
+        }
     }
 }


### PR DESCRIPTION
Enhance the stability of the application host startup process and ensure the API is ready before tests proceed. This includes implementing a readiness probe to check API availability and ensuring the HTTPS developer certificate is set up correctly.