### PR TITLE
Disable privileged Ryuk and update lifecycle scripts in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,9 +25,9 @@
   "containerEnv": {
     "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED": "false"
   },
-  "onCreateCommand": "zsh ./.devcontainer/scripts/on-create.sh",
-  "postCreateCommand": "zsh ./.devcontainer/scripts/post-create.sh",
-  "postStartCommand": "zsh ./.devcontainer/scripts/post-start.sh",
+  "onCreateCommand": "bash ./.devcontainer/scripts/on-create.sh",
+  "postCreateCommand": "bash ./.devcontainer/scripts/post-create.sh",
+  "postStartCommand": "bash ./.devcontainer/scripts/post-start.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,9 @@
       "additionalVersions": "10.0.201"
     }
   },
+  "containerEnv": {
+    "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED": "false"
+  },
   "onCreateCommand": "zsh ./.devcontainer/scripts/on-create.sh",
   "postCreateCommand": "zsh ./.devcontainer/scripts/post-create.sh",
   "postStartCommand": "zsh ./.devcontainer/scripts/post-start.sh",

--- a/README.md
+++ b/README.md
@@ -27,3 +27,5 @@ Make sure you've read the [contribution guidelines](CONTRIBUTING.md)
 ## <a id="lnk-contribute">Troubleshooting</a>
 
 If you find an issue, you can submit a pull request (PRs are welcome 😀 !!) or [open an issue](https://github.com/kalic-io/agenda/issues/new). 
+
+If Testcontainers-based tests fail in the devcontainer because the Ryuk sidecar cannot start correctly, rebuild or reopen the devcontainer to apply the shared fix. The devcontainer now sets `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=false` so Ryuk runs without privileged mode in Docker-in-Docker.

--- a/tests/Agenda.API.IntegrationTests/Fixtures/DistributedApplicationTestingBuilderFactory.cs
+++ b/tests/Agenda.API.IntegrationTests/Fixtures/DistributedApplicationTestingBuilderFactory.cs
@@ -29,7 +29,9 @@ namespace Agenda.API.IntegrationTests.Fixtures;
 public static class DistributedApplicationTestingBuilderFactory
 {
     private static readonly TimeSpan s_defaultTimeout = 30.Seconds();
+#pragma warning disable IDE1006 // Styles d'affectation de noms
     private static int s_httpsCertificateChecked;
+#pragma warning restore IDE1006 // Styles d'affectation de noms
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DistributedApplicationTestingBuilderFactory"/> class.


### PR DESCRIPTION
Disable the privileged mode for Ryuk in the devcontainer to improve compatibility. Update lifecycle scripts to run with bash instead of zsh. Suppress IDE warnings related to naming style in the testing factory.