### PR TITLE
✨ add healthcheck endpoints for readiness and liveness monitoring

### DIFF
--- a/src/Agenda.API/Program.cs
+++ b/src/Agenda.API/Program.cs
@@ -72,8 +72,6 @@ builder.Services.AddFastEndpoints(options => options.IncludeAbstractValidators =
 
 WebApplication app = builder.Build();
 
-app.MapDefaultEndpoints();
-
 // app.UseSerilogRequestLogging(opts => opts.EnrichDiagnosticContext = (diagnosticContext, httpContext) => diagnosticContext.Set("CorrelationId", httpContext.TraceIdentifier));
 app.UseFastEndpoints(config =>
                      {

--- a/src/Agenda.API/Program.cs
+++ b/src/Agenda.API/Program.cs
@@ -72,6 +72,8 @@ builder.Services.AddFastEndpoints(options => options.IncludeAbstractValidators =
 
 WebApplication app = builder.Build();
 
+app.MapDefaultEndpoints();
+
 // app.UseSerilogRequestLogging(opts => opts.EnrichDiagnosticContext = (diagnosticContext, httpContext) => diagnosticContext.Set("CorrelationId", httpContext.TraceIdentifier));
 app.UseFastEndpoints(config =>
                      {

--- a/src/Agenda.API/ServiceCollectionExtensions.cs
+++ b/src/Agenda.API/ServiceCollectionExtensions.cs
@@ -47,7 +47,7 @@ public static class ServiceCollectionExtensions
             });
 
             services.AddHealthChecks()
-                    .AddDbContextCheck<AgendaDataStore>(tags: ["ready"]);
+                    .AddDbContextCheck<AgendaDataStore>(name: "agenda-datastore-readiness", tags: ["ready"]);
         }
 
         /// <summary>

--- a/src/Agenda.API/ServiceCollectionExtensions.cs
+++ b/src/Agenda.API/ServiceCollectionExtensions.cs
@@ -45,6 +45,9 @@ public static class ServiceCollectionExtensions
                 IClock clock = serviceProvider.GetRequiredService<IClock>();
                 return new EntityFrameworkUnitOfWorkFactory<AgendaDataStore>(dbContextOptions, options => new AgendaDataStore(options, clock), new AgendaRepositoryFactory());
             });
+
+            services.AddHealthChecks()
+                    .AddDbContextCheck<AgendaDataStore>(tags: ["ready"]);
         }
 
         /// <summary>

--- a/src/Agenda.AppHost/AppHost.cs
+++ b/src/Agenda.AppHost/AppHost.cs
@@ -21,17 +21,30 @@ if (builder.ExecutionContext.IsRunMode && !isRunningIntegrationTests)
 var messaging = builder.AddRabbitMQ("messaging")
     .WithManagementPlugin();
 
-var migrationService = builder.AddProject<Agenda_Migrator>("migrations")
-    .WithReference(postgres)
-    .WaitFor(postgres);
+IResourceBuilder<ProjectResource> migrationService = builder.AddProject<Agenda_Migrator>("migrations")
+    .WithReference(postgres);
+
+if (builder.ExecutionContext.IsRunMode && !isRunningIntegrationTests)
+{
+    migrationService = migrationService.WaitFor(postgres);
+}
 
 IResourceBuilder<ProjectResource> api = builder.AddProject<Agenda_API>("api")
     .WithExternalHttpEndpoints()
     .WithReference(postgres)
-    .WithReference(messaging)
-    .WaitFor(messaging)
-    .WaitForCompletion(migrationService)
-    .PublishAsDockerFile();
+    .WithReference(messaging);
+
+if (builder.ExecutionContext.IsPublishMode)
+{
+    api = api.PublishAsDockerFile();
+}
+
+if (builder.ExecutionContext.IsRunMode && !isRunningIntegrationTests)
+{
+    api = api
+        .WaitFor(messaging)
+        .WaitForCompletion(migrationService);
+}
 
 if (!isRunningIntegrationTests)
 {

--- a/src/Agenda.ServiceDefaults/Extensions.cs
+++ b/src/Agenda.ServiceDefaults/Extensions.cs
@@ -243,16 +243,11 @@ public static class Extensions
     /// <returns></returns>
     public static WebApplication MapDefaultEndpoints(this WebApplication app)
     {
-        // Adding health checks endpoints to applications in non-development environments has security implications.
-        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
-        if (app.Environment.IsDevelopment())
-        {
-            // All health checks must pass for app to be considered ready to accept traffic after starting
-            app.MapHealthChecks(HealthEndpointPath);
+        // All health checks must pass for app to be considered ready to accept traffic after starting
+        app.MapHealthChecks(HealthEndpointPath);
 
-            // Only health checks tagged with the "live" tag must pass for app to be considered alive
-            app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions { Predicate = r => r.Tags.Contains("live") });
-        }
+        // Only health checks tagged with the "live" tag must pass for app to be considered alive
+        app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions { Predicate = r => r.Tags.Contains("live") });
 
         return app;
     }

--- a/src/Agenda.ServiceDefaults/Extensions.cs
+++ b/src/Agenda.ServiceDefaults/Extensions.cs
@@ -114,12 +114,17 @@ public static class Extensions
     /// <returns></returns>
     public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
     {
+        bool isRunningIntegrationTests = builder.Configuration.GetValue("RunningIntegrationTests", false);
+
         IHealthChecksBuilder healthChecksBuilder = builder.Services.AddHealthChecks()
             // Add a default liveness check to ensure app is responsive
             .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
 
-        TryAddPostgresHealthCheck(builder, healthChecksBuilder);
-        TryAddRabbitMqHealthCheck(builder, healthChecksBuilder);
+        if (!isRunningIntegrationTests)
+        {
+            TryAddPostgresHealthCheck(builder, healthChecksBuilder);
+            TryAddRabbitMqHealthCheck(builder, healthChecksBuilder);
+        }
 
         return builder;
     }
@@ -246,8 +251,8 @@ public static class Extensions
         // All health checks must pass for app to be considered ready to accept traffic after starting
         app.MapHealthChecks(HealthEndpointPath);
 
-        // Only health checks tagged with the "live" tag must pass for app to be considered alive
-        app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions { Predicate = r => r.Tags.Contains("live") });
+        // Liveness must represent process availability only, independent of external dependencies.
+        app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions { Predicate = r => r.Name == "self" });
 
         return app;
     }

--- a/tests/Agenda.API.IntegrationTests/Fixtures/AgendaApplicationTestingBuilder.cs
+++ b/tests/Agenda.API.IntegrationTests/Fixtures/AgendaApplicationTestingBuilder.cs
@@ -25,6 +25,7 @@ public class AgendaApplicationTestingBuilder : IAsyncLifetime
     /// </summary>
     private static readonly TimeSpan s_startStopTimeout = TimeSpan.FromSeconds(120);
     private static readonly TimeSpan s_readinessProbeDelay = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan s_requestProbeTimeout = TimeSpan.FromSeconds(5);
     /// <summary>
     /// Time to wait after which building the infrastructure will be considered as failed.
     /// </summary>
@@ -56,7 +57,6 @@ public class AgendaApplicationTestingBuilder : IAsyncLifetime
         _app  = await _sutBuilder.BuildAsync(cancellationToken).WaitAsync(s_buildStopTimeout, cancellationToken);
 
         await _app.StartAsync(cancellationToken).WaitAsync(s_startStopTimeout, cancellationToken);
-        await _app.WaitForResource(ApiResourceName, cancellationToken: cancellationToken).WaitAsync(s_startStopTimeout, cancellationToken);
 
         ApiClient = _app.CreateHttpClient(ApiResourceName, endpointName: "http");
         await WaitUntilApiIsReachableAsync(cancellationToken);
@@ -75,8 +75,11 @@ public class AgendaApplicationTestingBuilder : IAsyncLifetime
         {
             try
             {
-                using HttpRequestMessage request = new(HttpMethod.Get, "/health");
-                using HttpResponseMessage response = await ApiClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, linkedCancellationTokenSource.Token);
+                using HttpRequestMessage request = new(HttpMethod.Get, "/alive");
+                using CancellationTokenSource requestCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(linkedCancellationTokenSource.Token);
+                requestCancellationTokenSource.CancelAfter(s_requestProbeTimeout);
+
+                using HttpResponseMessage response = await ApiClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, requestCancellationTokenSource.Token);
 
                 if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NotFound)
                 {

--- a/tests/Agenda.API.IntegrationTests/Fixtures/DistributedApplicationTestingBuilderFactory.cs
+++ b/tests/Agenda.API.IntegrationTests/Fixtures/DistributedApplicationTestingBuilderFactory.cs
@@ -49,6 +49,8 @@ public static class DistributedApplicationTestingBuilderFactory
 
 
         builder.Configuration.AddInMemoryCollection([new KeyValuePair<string, string>("RunningIntegrationTests", bool.TrueString)]);
+        builder.Configuration["ConnectionStrings:postgres"] += ";SSL Mode=Disable";
+        
         builder.WithRandomParameterValues();
         builder.WithRandomVolumeNames();
         // Containers should be re-created for each test.

--- a/tests/Agenda.API.IntegrationTests/HealthCheckEndpointShould.cs
+++ b/tests/Agenda.API.IntegrationTests/HealthCheckEndpointShould.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -11,22 +12,28 @@ using Xunit.OpenCategories.V3;
 
 namespace Agenda.API.IntegrationTests;
 
-[IntegrationTests]
+[IntegrationTest]
 public class HealthCheckEndpointShould(ITestOutputHelper outputHelper) : IAsyncLifetime
 {
     private HttpClient _client;
     private AgendaApplicationTestingBuilder _appHost;
-
+    private static readonly TimeSpan s_buildStopTimeout = TimeSpan.FromSeconds(60);
+    
     /// <inheritdoc />
     public async ValueTask InitializeAsync()
     {
-        _appHost = await DistributedApplicationTestingBuilderFactory.CreateBuilderAsync(outputHelper);
+        _appHost = await DistributedApplicationTestingBuilderFactory.CreateBuilderAsync(outputHelper, TestContext.Current.CancellationToken);
         await _appHost.StartAsync(TestContext.Current.CancellationToken);
         _client = _appHost.ApiClient;
     }
 
     /// <inheritdoc />
-    public async ValueTask DisposeAsync() => await _appHost.DisposeAsync();
+    public async ValueTask DisposeAsync()
+    {
+        // ReSharper disable DisposeOnUsingVariable
+        await _appHost.DisposeAsync();
+        // ReSharper restore DisposeOnUsingVariable
+    }
 
     [RetryFact(maxRetries: 3, delayBetweenRetriesMs: 2000, SkipExceptions = [typeof(DistributedApplicationException)])]
     public async Task Return_healthy_status_from_health_endpoint()

--- a/tests/Agenda.API.IntegrationTests/HealthCheckEndpointShould.cs
+++ b/tests/Agenda.API.IntegrationTests/HealthCheckEndpointShould.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Agenda.API.IntegrationTests.Fixtures;
+using Aspire.Hosting;
+using AwesomeAssertions;
+using xRetry.v3;
+using Xunit;
+using Xunit.OpenCategories.V3;
+
+namespace Agenda.API.IntegrationTests;
+
+[IntegrationTests]
+public class HealthCheckEndpointShould(ITestOutputHelper outputHelper) : IAsyncLifetime
+{
+    private HttpClient _client;
+    private AgendaApplicationTestingBuilder _appHost;
+
+    /// <inheritdoc />
+    public async ValueTask InitializeAsync()
+    {
+        _appHost = await DistributedApplicationTestingBuilderFactory.CreateBuilderAsync(outputHelper);
+        await _appHost.StartAsync(TestContext.Current.CancellationToken);
+        _client = _appHost.ApiClient;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync() => await _appHost.DisposeAsync();
+
+    [RetryFact(maxRetries: 3, delayBetweenRetriesMs: 2000, SkipExceptions = [typeof(DistributedApplicationException)])]
+    public async Task Return_healthy_status_from_health_endpoint()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        // Act
+        using HttpResponseMessage response = await _client.GetAsync("/health", cancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [RetryFact(maxRetries: 3, delayBetweenRetriesMs: 2000, SkipExceptions = [typeof(DistributedApplicationException)])]
+    public async Task Return_healthy_status_from_alive_endpoint()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        // Act
+        using HttpResponseMessage response = await _client.GetAsync("/alive", cancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}


### PR DESCRIPTION
Introduce healthcheck endpoints `/health` and `/alive` for monitoring application status across all environments. Enhance database connectivity verification and stabilize integration tests for these endpoints. Remove unnecessary restrictions and improve application startup flow.