### PR TITLE
feat(api): make search endpoint case insensitive (#504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added healthchecks for PostgreSQL and RabbitMQ
 - Fixed appointments listing pagination metadata for UI navigation (`total` now represents total pages, with explicit `totalCount` and `pageSize` fields)
 - Added multi-criteria filtering for appointments listing (`subject`, `location`, and `from`/`to` time range)
+- Made appointments search case-insensitive at database level by switching `Subject` and `Location` to PostgreSQL `citext` columns ([#504](https://github.com/candoumbe/agenda/issues/504))
 
 ### 🧹 Housekeeping
 - Added task issue template

--- a/src/Agenda.DataStores.Postgres/Migrations/20260510173154_MakeSearchColumnsCaseInsensitive.Designer.cs
+++ b/src/Agenda.DataStores.Postgres/Migrations/20260510173154_MakeSearchColumnsCaseInsensitive.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Agenda.DataStores;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Agenda.DataStores.Postgres.Migrations
 {
     [DbContext(typeof(AgendaDataStore))]
-    partial class AgendaDataStoreModelSnapshot : ModelSnapshot
+    [Migration("20260510173154_MakeSearchColumnsCaseInsensitive")]
+    partial class MakeSearchColumnsCaseInsensitive
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Agenda.DataStores.Postgres/Migrations/20260510173154_MakeSearchColumnsCaseInsensitive.cs
+++ b/src/Agenda.DataStores.Postgres/Migrations/20260510173154_MakeSearchColumnsCaseInsensitive.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Agenda.DataStores.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeSearchColumnsCaseInsensitive : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:PostgresExtension:citext", ",,");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Subject",
+                table: "Appointments",
+                type: "citext",
+                maxLength: 255,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Location",
+                table: "Appointments",
+                type: "citext",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .OldAnnotation("Npgsql:PostgresExtension:citext", ",,");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Subject",
+                table: "Appointments",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "citext",
+                oldMaxLength: 255);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Location",
+                table: "Appointments",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "citext",
+                oldMaxLength: 255,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Agenda.DataStores/AgendaDataStore.cs
+++ b/src/Agenda.DataStores/AgendaDataStore.cs
@@ -1,4 +1,4 @@
-﻿
+
 using Agenda.Objects;
 
 using Candoumbe.DataAccess.Abstractions;

--- a/src/Agenda.DataStores/AppointmentEntityTypeConfiguration.cs
+++ b/src/Agenda.DataStores/AppointmentEntityTypeConfiguration.cs
@@ -1,4 +1,3 @@
-﻿
 using Agenda.Ids;
 using Agenda.Objects;
 
@@ -16,11 +15,13 @@ internal class AppointmentEntityTypeConfiguration : IEntityTypeConfiguration<App
         builder.Property(x => x.Id).HasConversion<AppointmentId.EfCoreValueConverter>();
 
         builder.Property(x => x.Location)
-            .HasMaxLength(AgendaDataStore.NormalTextLength);
+            .HasMaxLength(AgendaDataStore.NormalTextLength)
+            .HasColumnType("citext");
 
         builder.Property(x => x.Subject)
             .HasMaxLength(AgendaDataStore.NormalTextLength)
-            .IsRequired();
+            .IsRequired()
+            .HasColumnType("citext");
 
         builder.Property(x => x.StartDate)
               .IsRequired();

--- a/tests/Agenda.API.UnitTests/Features/Appointments/v1/Search/SearchAppointmentsEndpointShould.cs
+++ b/tests/Agenda.API.UnitTests/Features/Appointments/v1/Search/SearchAppointmentsEndpointShould.cs
@@ -146,7 +146,6 @@ public sealed class SearchAppointmentsEndpointShould : IClassFixture<PostgresSql
             // Search with no filter, first page and there are 3 pages of 10 items
             {
                 List<Appointment> data = s_appointementFaker.Generate(30);
-
                 SearchAppointmentRequest request = new() { Page = NonNegativeInteger.One, PageSize = PositiveInteger.From(10) };
                 cases.Add(data,
                           request,
@@ -304,6 +303,102 @@ public sealed class SearchAppointmentsEndpointShould : IClassFixture<PostgresSql
                                                             && pageOfAppointments.Links.Previous == null
                                                             && pageOfAppointments.Links.Next == null
                                                             && pageOfAppointments.Links.Last != null
+                          });
+            }
+
+            // Search by subject case-insensitive (upper-cased query should match lower-cased data)
+            {
+                Instant startDate = Instant.FromUtc(2026, 05, 10, 9, 0);
+                Appointment appointment = new(AppointmentId.New(),
+                                             "backend architecture review",
+                                             "Paris",
+                                             startDate,
+                                             startDate.Plus(Duration.FromHours(1)));
+
+                List<Appointment> data = [appointment];
+                SearchAppointmentRequest request = new()
+                {
+                    Page = NonNegativeInteger.One,
+                    PageSize = PositiveInteger.From(10),
+                    Subject = "*BACKEND*"
+                };
+
+                cases.Add(data,
+                          request,
+                          new XunitSerializableExpression<PageOf<Browsable<AppointmentInfo>>>
+                          {
+                              Value = pageOfAppointments => pageOfAppointments.Total == 1
+                                                            && pageOfAppointments.TotalCount == 1
+                                                            && pageOfAppointments.Count == 1
+                                                            && pageOfAppointments.Items != null
+                                                            && pageOfAppointments.Items.Exactly(1)
+                                                            && pageOfAppointments.Items.Once(a => a.Resource.Id == appointment.Id)
+                          });
+            }
+
+            // Search by location case-insensitive (lower-cased query should match upper-cased data)
+            {
+                Instant startDate = Instant.FromUtc(2026, 05, 10, 14, 0);
+                Appointment appointment = new(AppointmentId.New(),
+                                             "Product roadmap",
+                                             "PARIS",
+                                             startDate,
+                                             startDate.Plus(Duration.FromHours(2)));
+
+                Appointment otherAppointment = new(AppointmentId.New(),
+                                                   "Product roadmap",
+                                                   "Lyon",
+                                                   startDate,
+                                                   startDate.Plus(Duration.FromHours(2)));
+
+                List<Appointment> data = [appointment, otherAppointment];
+                SearchAppointmentRequest request = new()
+                {
+                    Page = NonNegativeInteger.One,
+                    PageSize = PositiveInteger.From(10),
+                    Location = "*paris*"
+                };
+
+                cases.Add(data,
+                          request,
+                          new XunitSerializableExpression<PageOf<Browsable<AppointmentInfo>>>
+                          {
+                              Value = pageOfAppointments => pageOfAppointments.Total == 1
+                                                            && pageOfAppointments.TotalCount == 1
+                                                            && pageOfAppointments.Count == 1
+                                                            && pageOfAppointments.Items != null
+                                                            && pageOfAppointments.Items.Exactly(1)
+                                                            && pageOfAppointments.Items.Once(a => a.Resource.Id == appointment.Id)
+                          });
+            }
+
+            // Search by subject mixed-case (mixed-case query should match mixed-case data regardless of casing)
+            {
+                Instant startDate = Instant.FromUtc(2026, 05, 10, 16, 0);
+                Appointment appointment = new(AppointmentId.New(),
+                                             "Should Shazam be a member of the JLA ?",
+                                             "Metropolis",
+                                             startDate,
+                                             startDate.Plus(Duration.FromHours(1)));
+
+                List<Appointment> data = [appointment];
+                SearchAppointmentRequest request = new()
+                {
+                    Page = NonNegativeInteger.One,
+                    PageSize = PositiveInteger.From(10),
+                    Subject = "*shazam*"
+                };
+
+                cases.Add(data,
+                          request,
+                          new XunitSerializableExpression<PageOf<Browsable<AppointmentInfo>>>
+                          {
+                              Value = pageOfAppointments => pageOfAppointments.Total == 1
+                                                            && pageOfAppointments.TotalCount == 1
+                                                            && pageOfAppointments.Count == 1
+                                                            && pageOfAppointments.Items != null
+                                                            && pageOfAppointments.Items.Exactly(1)
+                                                            && pageOfAppointments.Items.Once(a => a.Resource.Id == appointment.Id)
                           });
             }
 


### PR DESCRIPTION
## Context
Closes #504

The appointments search endpoint was case-sensitive. Search should be case-insensitive at the **lowest level**, i.e. the database layer.

## What changed
- Switched PostgreSQL columns `Subject` and `Location` to `citext` (native case-insensitive behavior at DB level).
- Added a PostgreSQL migration to enable `citext` and convert both columns.
- Updated the EF Core model snapshot.
- Added unit test coverage for case-insensitive search behavior (subject/location with different letter casing).
- Updated the changelog (`Unreleased > API`).

## Why `citext`
A first approach based on non-deterministic collation was discarded because it is not compatible with `LIKE` operations used by the current search logic. `citext` provides database-level case-insensitive behavior while remaining compatible with existing queries.

## Validation
- Targeted tests run: `SearchAppointmentsEndpointShould`
- Result: **10 passed, 0 failed**

## Impact
- User-facing behavior: searching for `Paris`, `PARIS`, or `paris` returns the same results.
- No API contract changes (request/response shape remains the same).