### PR TITLE
feat(events): Emit AppointmentCreated event when appointments are created (#329)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -493,3 +493,4 @@ StrykerOutput/
 .squad/.scratch/
 # Squad: SubSquad activation file (local to this machine)
 .squad-workstream
+.devcontainer/devcontainer-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `DELETE /appointments/{id}/attendees/{id}` endpoint
 - Added RabbitMQ integration and related configuration.
 - Added publication of `AppointmentScheduled` event when a new appointment is scheduled : 
+- Added publication of `AppointmentCreated` event when a new appointment is created, containing appointment ID, start/end dates (ISO 8601), location, attendees list, and creator ID (#329)
 - Added healthchecks for PostgreSQL and RabbitMQ
 - Fixed appointments listing pagination metadata for UI navigation (`total` now represents total pages, with explicit `totalCount` and `pageSize` fields)
 - Added multi-criteria filtering for appointments listing (`subject`, `location`, and `from`/`to` time range)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,6 +56,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="NodaTime" Version="3.3.2" />
     <PackageVersion Include="NodaTime.Bogus" Version="3.0.2" />
     <PackageVersion Include="NodaTime.Serialization.JsonNet" Version="3.2.1" />
     <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.3.1" />

--- a/src/Agenda.API/Features/Appointments/v1/Create/CreateAppointmentEndpoint.cs
+++ b/src/Agenda.API/Features/Appointments/v1/Create/CreateAppointmentEndpoint.cs
@@ -83,7 +83,22 @@ public partial class CreateAppointmentEndpoint : Endpoint<NewAppointmentInfo, Cr
                                                                             })
                                                              ]);
 
+        AppointmentCreated appointmentCreatedEvent = new(newAppointment.Id,
+                                                         newAppointment.StartDate,
+                                                         newAppointment.EndDate,
+                                                         newAppointment.Location,
+                                                         [
+                                                             ..newAppointment.Attendees.Select(a => new Agenda.Events.Attendee()
+                                                                        {
+                                                                            Id = a.Id.Value,
+                                                                            FirstName = a.Name,
+                                                                            LastName = a.Email
+                                                                        })
+                                                         ],
+                                                         "system");
+
         await _commandProcessor.DepositPostAsync(appointmentScheduledEvent, cancellationToken: ct);
+        await _commandProcessor.DepositPostAsync(appointmentCreatedEvent, cancellationToken: ct);
         await unitOfWork.SaveChangesAsync(ct).ConfigureAwait(false);
 
         DateTimeZone zone = _currentRequestMetadataInfoProvider.GetCurrentDateTimeZone();

--- a/src/Agenda.API/ServiceCollectionExtensions.cs
+++ b/src/Agenda.API/ServiceCollectionExtensions.cs
@@ -120,8 +120,13 @@ public static class ServiceCollectionExtensions
                             MakeChannels = OnMissingChannel.Create,
                             WaitForConfirmsTimeOutInMilliseconds = 1000,
                             Subject = "appointment/scheduled",
-
-
+                        },
+                        new RmqPublication<AppointmentCreated>()
+                        {
+                            Topic = "agenda.appointments.created",
+                            MakeChannels = OnMissingChannel.Create,
+                            WaitForConfirmsTimeOutInMilliseconds = 1000,
+                            Subject = "appointment/created",
                         }
                     ];
                     producers.ProducerRegistry = new RmqProducerRegistryFactory(rmqMessagingGatewayConnection, publications).Create();

--- a/src/Agenda.Events/Agenda.Events.csproj
+++ b/src/Agenda.Events/Agenda.Events.csproj
@@ -10,5 +10,6 @@
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Api" />
     <PackageReference Include="Paramore.Brighter" />
+    <PackageReference Include="NodaTime" />
   </ItemGroup>
 </Project>

--- a/src/Agenda.Events/AppointmentCreated.cs
+++ b/src/Agenda.Events/AppointmentCreated.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using Agenda.Ids;
+using NodaTime;
+using Paramore.Brighter;
+
+namespace Agenda.Events;
+
+/// <summary>
+/// Event raised when a new appointment is created.
+/// </summary>
+public class AppointmentCreated(AppointmentId appointmentId, Instant startDate, Instant endDate, string location, IReadOnlyList<Attendee> attendees, string creatorId)
+#if NET10_0_OR_GREATER
+    : Event(Guid.CreateVersion7())
+#else
+    : Event(Guid.NewGuid())
+#endif
+{
+    /// <summary>
+    /// Unique identifier of the appointment.
+    /// </summary>
+    public AppointmentId AppointmentId { get; } = appointmentId;
+
+    /// <summary>
+    /// Start date of the appointment in ISO 8601 format (UTC).
+    /// </summary>
+    public Instant StartDate { get; } = startDate;
+
+    /// <summary>
+    /// End date of the appointment in ISO 8601 format (UTC).
+    /// </summary>
+    public Instant EndDate { get; } = endDate;
+
+    /// <summary>
+    /// Location of the appointment.
+    /// </summary>
+    public string Location { get; } = location ?? throw new ArgumentNullException(nameof(location));
+
+    /// <summary>
+    /// Attendees of the appointment.
+    /// </summary>
+    public IReadOnlyList<Attendee> Attendees { get; } = attendees ?? throw new ArgumentNullException(nameof(attendees));
+
+    /// <summary>
+    /// Identifier of the user who created the appointment.
+    /// </summary>
+    public string CreatorId { get; } = creatorId ?? throw new ArgumentNullException(nameof(creatorId));
+}

--- a/tests/Agenda.API.UnitTests/Features/Appointments/v1/Create/CreateAppointementEndpointShould.cs
+++ b/tests/Agenda.API.UnitTests/Features/Appointments/v1/Create/CreateAppointementEndpointShould.cs
@@ -441,5 +441,164 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                 A<CancellationToken>._))
                 .MustHaveHappenedOnceExactly();
         }
+
+        [Fact]
+        public async Task Emit_AppointmentCreated_event_with_empty_location_when_no_location_provided()
+        {
+            // Arrange
+            NewAppointmentInfo req = new()
+            {
+                Id = AppointmentId.New(),
+                Subject = s_faker.Lorem.Sentence(),
+                Location = string.Empty,
+                StartDate = s_faker.Noda().ZonedDateTime.Past().ToOffsetDateTime(),
+                EndDate = s_faker.Noda().ZonedDateTime.Future().ToOffsetDateTime(),
+                Attendees = s_attendeeFaker.Generate(1),
+            };
+
+            A.CallTo(() => _linkGenerator.GetUriByAddress(A<HttpContext>.Ignored,
+                                                          A<string>.Ignored,
+                                                          A<RouteValueDictionary>.Ignored,
+                                                          A<RouteValueDictionary>.Ignored,
+                                                          A<string>.Ignored,
+                                                          A<HostString>.Ignored,
+                                                          A<PathString>.Ignored,
+                                                          A<FragmentString>.Ignored,
+                                                          A<LinkOptions>.Ignored))
+                .WithAnyArguments()
+                .Returns(s_faker.Internet.Url());
+
+            A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentScheduled>._,
+                                                              A<RequestContext>._,
+                                                              A<Dictionary<string, object>>._,
+                                                              A<bool>._,
+                                                              A<CancellationToken>._))
+                .ReturnsLazily((AppointmentScheduled evt, RequestContext _, Dictionary<string, object> _, bool _, CancellationToken _) => evt.Id);
+
+            A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentCreated>._,
+                                                              A<RequestContext>._,
+                                                              A<Dictionary<string, object>>._,
+                                                              A<bool>._,
+                                                              A<CancellationToken>._))
+                .ReturnsLazily((AppointmentCreated evt, RequestContext _, Dictionary<string, object> _, bool _, CancellationToken _) => evt.Id);
+
+            // Act
+            await _sut.ExecuteAsync(req, CancellationToken.None);
+
+            // Assert
+            A.CallTo(() => _commandProcessor.DepositPostAsync(A<AppointmentCreated>.That.Matches(evt =>
+                    evt.Location == string.Empty),
+                A<RequestContext>._,
+                A<Dictionary<string, object>>._,
+                A<bool>._,
+                A<CancellationToken>._))
+                .MustHaveHappenedOnceExactly();
+        }
+
+        [Fact]
+        public async Task Emit_AppointmentCreated_event_with_empty_attendees_list_when_none_provided()
+        {
+            // Arrange
+            NewAppointmentInfo req = new()
+            {
+                Id = AppointmentId.New(),
+                Subject = s_faker.Lorem.Sentence(),
+                Location = s_faker.Address.FullAddress(),
+                StartDate = s_faker.Noda().ZonedDateTime.Past().ToOffsetDateTime(),
+                EndDate = s_faker.Noda().ZonedDateTime.Future().ToOffsetDateTime(),
+                Attendees = null,
+            };
+
+            A.CallTo(() => _linkGenerator.GetUriByAddress(A<HttpContext>.Ignored,
+                                                          A<string>.Ignored,
+                                                          A<RouteValueDictionary>.Ignored,
+                                                          A<RouteValueDictionary>.Ignored,
+                                                          A<string>.Ignored,
+                                                          A<HostString>.Ignored,
+                                                          A<PathString>.Ignored,
+                                                          A<FragmentString>.Ignored,
+                                                          A<LinkOptions>.Ignored))
+                .WithAnyArguments()
+                .Returns(s_faker.Internet.Url());
+
+            A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentScheduled>._,
+                                                              A<RequestContext>._,
+                                                              A<Dictionary<string, object>>._,
+                                                              A<bool>._,
+                                                              A<CancellationToken>._))
+                .ReturnsLazily((AppointmentScheduled evt, RequestContext _, Dictionary<string, object> _, bool _, CancellationToken _) => evt.Id);
+
+            A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentCreated>._,
+                                                              A<RequestContext>._,
+                                                              A<Dictionary<string, object>>._,
+                                                              A<bool>._,
+                                                              A<CancellationToken>._))
+                .ReturnsLazily((AppointmentCreated evt, RequestContext _, Dictionary<string, object> _, bool _, CancellationToken _) => evt.Id);
+
+            // Act
+            await _sut.ExecuteAsync(req, CancellationToken.None);
+
+            // Assert
+            A.CallTo(() => _commandProcessor.DepositPostAsync(A<AppointmentCreated>.That.Matches(evt =>
+                    evt.Attendees.Count == 0),
+                A<RequestContext>._,
+                A<Dictionary<string, object>>._,
+                A<bool>._,
+                A<CancellationToken>._))
+                .MustHaveHappenedOnceExactly();
+        }
+
+        [Fact]
+        public async Task Emit_AppointmentCreated_event_with_system_creator_id()
+        {
+            // Arrange
+            NewAppointmentInfo req = new()
+            {
+                Id = AppointmentId.New(),
+                Subject = s_faker.Lorem.Sentence(),
+                Location = s_faker.Address.FullAddress(),
+                StartDate = s_faker.Noda().ZonedDateTime.Past().ToOffsetDateTime(),
+                EndDate = s_faker.Noda().ZonedDateTime.Future().ToOffsetDateTime(),
+                Attendees = s_attendeeFaker.Generate(1),
+            };
+
+            A.CallTo(() => _linkGenerator.GetUriByAddress(A<HttpContext>.Ignored,
+                                                          A<string>.Ignored,
+                                                          A<RouteValueDictionary>.Ignored,
+                                                          A<RouteValueDictionary>.Ignored,
+                                                          A<string>.Ignored,
+                                                          A<HostString>.Ignored,
+                                                          A<PathString>.Ignored,
+                                                          A<FragmentString>.Ignored,
+                                                          A<LinkOptions>.Ignored))
+                .WithAnyArguments()
+                .Returns(s_faker.Internet.Url());
+
+            A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentScheduled>._,
+                                                              A<RequestContext>._,
+                                                              A<Dictionary<string, object>>._,
+                                                              A<bool>._,
+                                                              A<CancellationToken>._))
+                .ReturnsLazily((AppointmentScheduled evt, RequestContext _, Dictionary<string, object> _, bool _, CancellationToken _) => evt.Id);
+
+            A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentCreated>._,
+                                                              A<RequestContext>._,
+                                                              A<Dictionary<string, object>>._,
+                                                              A<bool>._,
+                                                              A<CancellationToken>._))
+                .ReturnsLazily((AppointmentCreated evt, RequestContext _, Dictionary<string, object> _, bool _, CancellationToken _) => evt.Id);
+
+            // Act
+            await _sut.ExecuteAsync(req, CancellationToken.None);
+
+            // Assert
+            A.CallTo(() => _commandProcessor.DepositPostAsync(A<AppointmentCreated>.That.Matches(evt =>
+                    evt.CreatorId == "system"),
+                A<RequestContext>._,
+                A<Dictionary<string, object>>._,
+                A<bool>._,
+                A<CancellationToken>._))
+                .MustHaveHappenedOnceExactly();
+        }
     }
 }

--- a/tests/Agenda.API.UnitTests/Features/Appointments/v1/Create/CreateAppointementEndpointShould.cs
+++ b/tests/Agenda.API.UnitTests/Features/Appointments/v1/Create/CreateAppointementEndpointShould.cs
@@ -214,6 +214,9 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
             A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentScheduled>._, A<RequestContext>._, A<Dictionary<string, object>>._, A<bool>._, A<CancellationToken>._))
                 .ReturnsLazily((AppointmentScheduled evt, RequestContext _, Dictionary<string, object> _,  bool _, CancellationToken _) => evt.Id);
 
+            A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentCreated>._, A<RequestContext>._, A<Dictionary<string, object>>._, A<bool>._, A<CancellationToken>._))
+                .ReturnsLazily((AppointmentCreated evt, RequestContext _, Dictionary<string, object> _,  bool _, CancellationToken _) => evt.Id);
+
             // Act
             CreatedAtRoute<Browsable<AppointmentInfo>> response = await _sut.ExecuteAsync(req, CancellationToken.None);
 
@@ -236,6 +239,9 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                 .And.Contain(link => link.Relations.Once(rel => string.Equals(rel, "delete", StringComparison.OrdinalIgnoreCase)));
 
             A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentScheduled>._, A<RequestContext>._, A<Dictionary<string, object>>._, A<bool>._, A<CancellationToken>._))
+                .MustHaveHappenedOnceExactly();
+
+            A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentCreated>._, A<RequestContext>._, A<Dictionary<string, object>>._, A<bool>._, A<CancellationToken>._))
                 .MustHaveHappenedOnceExactly();
 
             A.CallTo(() => _repository.Create(An<Appointment>._, A<CancellationToken>._))
@@ -296,6 +302,137 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                     && evt.Location == req.Location
                     && evt.Participants.Count == req.Attendees.Count
                     && req.Attendees.All(attendee => evt.Participants.Any(participant =>
+                    participant.FirstName == attendee.Name
+                        && participant.LastName == attendee.Email))),
+                A<RequestContext>._,
+                A<Dictionary<string, object>>._,
+                A<bool>._,
+                A<CancellationToken>._))
+                .MustHaveHappenedOnceExactly();
+
+            A.CallTo(() => _commandProcessor.DepositPostAsync(A<AppointmentCreated>.That.Matches(evt =>
+                    evt.AppointmentId == req.Id
+                    && evt.StartDate == req.StartDate.ToInstant()
+                    && evt.EndDate == req.EndDate.ToInstant()
+                    && evt.Location == req.Location
+                    && evt.Attendees.Count == req.Attendees.Count
+                    && req.Attendees.All(attendee => evt.Attendees.Any(participant =>
+                    participant.FirstName == attendee.Name
+                        && participant.LastName == attendee.Email))
+                    && evt.CreatorId == "system"),
+                A<RequestContext>._,
+                A<Dictionary<string, object>>._,
+                A<bool>._,
+                A<CancellationToken>._))
+                .MustHaveHappenedOnceExactly();
+        }
+
+        [Fact]
+        public async Task Emit_AppointmentCreated_event_with_correct_data_when_appointment_is_created()
+        {
+            // Arrange
+            NewAppointmentInfo req = new()
+            {
+                Id = AppointmentId.New(),
+                Subject = s_faker.Lorem.Sentence(),
+                Location = s_faker.Address.FullAddress(),
+                StartDate = s_faker.Noda().ZonedDateTime.Past().ToOffsetDateTime(),
+                EndDate = s_faker.Noda().ZonedDateTime.Future().ToOffsetDateTime(),
+                Attendees = s_attendeeFaker.Generate(3),
+            };
+
+            A.CallTo(() => _linkGenerator.GetUriByAddress(A<HttpContext>.Ignored,
+                                                          A<string>.Ignored,
+                                                          A<RouteValueDictionary>.Ignored,
+                                                          A<RouteValueDictionary>.Ignored,
+                                                          A<string>.Ignored,
+                                                          A<HostString>.Ignored,
+                                                          A<PathString>.Ignored,
+                                                          A<FragmentString>.Ignored,
+                                                          A<LinkOptions>.Ignored))
+                .WithAnyArguments()
+                .Returns(s_faker.Internet.Url());
+
+            A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentScheduled>._,
+                                                              A<RequestContext>._,
+                                                              A<Dictionary<string, object>>._,
+                                                              A<bool>._,
+                                                              A<CancellationToken>._))
+                .ReturnsLazily((AppointmentScheduled evt, RequestContext _, Dictionary<string, object> _, bool _, CancellationToken _) => evt.Id);
+
+            A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentCreated>._,
+                                                              A<RequestContext>._,
+                                                              A<Dictionary<string, object>>._,
+                                                              A<bool>._,
+                                                              A<CancellationToken>._))
+                .ReturnsLazily((AppointmentCreated evt, RequestContext _, Dictionary<string, object> _, bool _, CancellationToken _) => evt.Id);
+
+            // Act
+            await _sut.ExecuteAsync(req, CancellationToken.None);
+
+            // Assert
+            A.CallTo(() => _commandProcessor.DepositPostAsync(A<AppointmentCreated>.That.Matches(evt =>
+                    evt.AppointmentId == req.Id
+                    && evt.StartDate == req.StartDate.ToInstant()
+                    && evt.EndDate == req.EndDate.ToInstant()
+                    && evt.Location == req.Location
+                    && evt.Attendees.Count == 3
+                    && evt.CreatorId == "system"),
+                A<RequestContext>._,
+                A<Dictionary<string, object>>._,
+                A<bool>._,
+                A<CancellationToken>._))
+                .MustHaveHappenedOnceExactly();
+        }
+
+        [Fact]
+        public async Task Include_all_attendees_in_AppointmentCreated_event()
+        {
+            // Arrange
+            IReadOnlyList<AttendeeInfo> attendees = s_attendeeFaker.Generate(5);
+            NewAppointmentInfo req = new()
+            {
+                Id = AppointmentId.New(),
+                Subject = s_faker.Lorem.Sentence(),
+                Location = s_faker.Address.FullAddress(),
+                StartDate = s_faker.Noda().ZonedDateTime.Past().ToOffsetDateTime(),
+                EndDate = s_faker.Noda().ZonedDateTime.Future().ToOffsetDateTime(),
+                Attendees = attendees,
+            };
+
+            A.CallTo(() => _linkGenerator.GetUriByAddress(A<HttpContext>.Ignored,
+                                                          A<string>.Ignored,
+                                                          A<RouteValueDictionary>.Ignored,
+                                                          A<RouteValueDictionary>.Ignored,
+                                                          A<string>.Ignored,
+                                                          A<HostString>.Ignored,
+                                                          A<PathString>.Ignored,
+                                                          A<FragmentString>.Ignored,
+                                                          A<LinkOptions>.Ignored))
+                .WithAnyArguments()
+                .Returns(s_faker.Internet.Url());
+
+            A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentScheduled>._,
+                                                              A<RequestContext>._,
+                                                              A<Dictionary<string, object>>._,
+                                                              A<bool>._,
+                                                              A<CancellationToken>._))
+                .ReturnsLazily((AppointmentScheduled evt, RequestContext _, Dictionary<string, object> _, bool _, CancellationToken _) => evt.Id);
+
+            A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentCreated>._,
+                                                              A<RequestContext>._,
+                                                              A<Dictionary<string, object>>._,
+                                                              A<bool>._,
+                                                              A<CancellationToken>._))
+                .ReturnsLazily((AppointmentCreated evt, RequestContext _, Dictionary<string, object> _, bool _, CancellationToken _) => evt.Id);
+
+            // Act
+            await _sut.ExecuteAsync(req, CancellationToken.None);
+
+            // Assert
+            A.CallTo(() => _commandProcessor.DepositPostAsync(A<AppointmentCreated>.That.Matches(evt =>
+                    evt.Attendees.Count == attendees.Count
+                    && attendees.All(attendee => evt.Attendees.Any(participant =>
                     participant.FirstName == attendee.Name
                         && participant.LastName == attendee.Email))),
                 A<RequestContext>._,

--- a/tests/Agenda.API.UnitTests/Features/Appointments/v1/Create/CreateAppointementEndpointShould.cs
+++ b/tests/Agenda.API.UnitTests/Features/Appointments/v1/Create/CreateAppointementEndpointShould.cs
@@ -284,6 +284,13 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                                                               A<CancellationToken>._))
                 .ReturnsLazily((AppointmentScheduled evt, RequestContext _, Dictionary<string, object> _, bool _, CancellationToken _) => evt.Id);
 
+            A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentCreated>._,
+                                                              A<RequestContext>._,
+                                                              A<Dictionary<string, object>>._,
+                                                              A<bool>._,
+                                                              A<CancellationToken>._))
+                .ReturnsLazily((AppointmentCreated evt, RequestContext _, Dictionary<string, object> _, bool _, CancellationToken _) => evt.Id);
+
             // Act
             await _sut.ExecuteAsync(req, CancellationToken.None);
 

--- a/tests/Agenda.API.UnitTests/Features/Events/AppointmentCreatedShould.cs
+++ b/tests/Agenda.API.UnitTests/Features/Events/AppointmentCreatedShould.cs
@@ -13,12 +13,7 @@ namespace Agenda.API.UnitTests.Features.Events
     [UnitTest]
     public class AppointmentCreatedShould
     {
-        private static readonly Faker s_faker;
-
-        static AppointmentCreatedShould()
-        {
-            s_faker = new Faker();
-        }
+        private static readonly Faker s_faker =  new ();
 
         [Fact]
         public void Build_with_required_data()
@@ -61,11 +56,12 @@ namespace Agenda.API.UnitTests.Features.Events
             IReadOnlyList<Attendee> attendees = [];
             string creatorId = "user-123";
 
-            // Act & Assert
-            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
-                new AppointmentCreated(appointmentId, startDate, endDate, null!, attendees, creatorId));
+            // Act
+            Action buildEventWithNullLocation = () => _ = new AppointmentCreated(appointmentId, startDate, endDate, null!, attendees, creatorId);
 
-            exception.ParamName.Should().Be("location");
+            // Assert
+            buildEventWithNullLocation.Should().Throw<ArgumentNullException>()
+                .WithParameterName("location");
         }
 
         [Fact]
@@ -78,11 +74,12 @@ namespace Agenda.API.UnitTests.Features.Events
             string location = s_faker.Address.FullAddress();
             string creatorId = "user-123";
 
-            // Act & Assert
-            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
-                new AppointmentCreated(appointmentId, startDate, endDate, location, null!, creatorId));
+            // Act
+            Action buildEventWithAttendeesNull = () => _ = new AppointmentCreated(appointmentId, startDate, endDate, location, null!, creatorId);
 
-            exception.ParamName.Should().Be("attendees");
+            // Assert
+            buildEventWithAttendeesNull.Should().Throw<ArgumentNullException>()
+                .WithParameterName("attendees");
         }
 
         [Fact]
@@ -95,11 +92,12 @@ namespace Agenda.API.UnitTests.Features.Events
             string location = s_faker.Address.FullAddress();
             IReadOnlyList<Attendee> attendees = [];
 
-            // Act & Assert
-            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
-                new AppointmentCreated(appointmentId, startDate, endDate, location, attendees, null!));
+            // Act
+            Action buildEventWithCreatorNull = () => _ = new AppointmentCreated(appointmentId, startDate, endDate, location, attendees, null!);
 
-            exception.ParamName.Should().Be("creatorId");
+            // Assert
+            buildEventWithCreatorNull.Should().Throw<ArgumentNullException>()
+                .WithParameterName("creatorId");
         }
 
         [Fact]

--- a/tests/Agenda.API.UnitTests/Features/Events/AppointmentCreatedShould.cs
+++ b/tests/Agenda.API.UnitTests/Features/Events/AppointmentCreatedShould.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using Agenda.Events;
+using Agenda.Ids;
+using AwesomeAssertions;
+using Bogus;
+using NodaTime;
+using Xunit;
+using Xunit.OpenCategories.V3;
+
+namespace Agenda.API.UnitTests.Features.Events
+{
+    [UnitTest]
+    public class AppointmentCreatedShould
+    {
+        private static readonly Faker s_faker;
+
+        static AppointmentCreatedShould()
+        {
+            s_faker = new Faker();
+        }
+
+        [Fact]
+        public void Build_with_required_data()
+        {
+            // Arrange
+            AppointmentId appointmentId = AppointmentId.New();
+            Instant startDate = SystemClock.Instance.GetCurrentInstant();
+            Instant endDate = startDate.Plus(Duration.FromHours(1));
+            string location = s_faker.Address.FullAddress();
+            IReadOnlyList<Attendee> attendees = new[]
+            {
+                new Attendee
+                {
+                    Id = Guid.NewGuid(),
+                    FirstName = s_faker.Name.FirstName(),
+                    LastName = s_faker.Name.LastName()
+                }
+            };
+            string creatorId = "user-123";
+
+            // Act
+            AppointmentCreated appointmentCreated = new(appointmentId, startDate, endDate, location, attendees, creatorId);
+
+            // Assert
+            appointmentCreated.AppointmentId.Should().Be(appointmentId);
+            appointmentCreated.StartDate.Should().Be(startDate);
+            appointmentCreated.EndDate.Should().Be(endDate);
+            appointmentCreated.Location.Should().Be(location);
+            appointmentCreated.Attendees.Should().HaveSameCount(attendees);
+            appointmentCreated.CreatorId.Should().Be(creatorId);
+        }
+
+        [Fact]
+        public void Throw_when_location_is_null()
+        {
+            // Arrange
+            AppointmentId appointmentId = AppointmentId.New();
+            Instant startDate = SystemClock.Instance.GetCurrentInstant();
+            Instant endDate = startDate.Plus(Duration.FromHours(1));
+            IReadOnlyList<Attendee> attendees = [];
+            string creatorId = "user-123";
+
+            // Act & Assert
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
+                new AppointmentCreated(appointmentId, startDate, endDate, null!, attendees, creatorId));
+
+            exception.ParamName.Should().Be("location");
+        }
+
+        [Fact]
+        public void Throw_when_attendees_is_null()
+        {
+            // Arrange
+            AppointmentId appointmentId = AppointmentId.New();
+            Instant startDate = SystemClock.Instance.GetCurrentInstant();
+            Instant endDate = startDate.Plus(Duration.FromHours(1));
+            string location = s_faker.Address.FullAddress();
+            string creatorId = "user-123";
+
+            // Act & Assert
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
+                new AppointmentCreated(appointmentId, startDate, endDate, location, null!, creatorId));
+
+            exception.ParamName.Should().Be("attendees");
+        }
+
+        [Fact]
+        public void Throw_when_creatorId_is_null()
+        {
+            // Arrange
+            AppointmentId appointmentId = AppointmentId.New();
+            Instant startDate = SystemClock.Instance.GetCurrentInstant();
+            Instant endDate = startDate.Plus(Duration.FromHours(1));
+            string location = s_faker.Address.FullAddress();
+            IReadOnlyList<Attendee> attendees = [];
+
+            // Act & Assert
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() =>
+                new AppointmentCreated(appointmentId, startDate, endDate, location, attendees, null!));
+
+            exception.ParamName.Should().Be("creatorId");
+        }
+
+        [Fact]
+        public void Allow_empty_location()
+        {
+            // Arrange
+            AppointmentId appointmentId = AppointmentId.New();
+            Instant startDate = SystemClock.Instance.GetCurrentInstant();
+            Instant endDate = startDate.Plus(Duration.FromHours(1));
+            IReadOnlyList<Attendee> attendees = [];
+            string creatorId = "system";
+
+            // Act
+            AppointmentCreated appointmentCreated = new(appointmentId, startDate, endDate, string.Empty, attendees, creatorId);
+
+            // Assert
+            appointmentCreated.Location.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void Allow_empty_attendees_list()
+        {
+            // Arrange
+            AppointmentId appointmentId = AppointmentId.New();
+            Instant startDate = SystemClock.Instance.GetCurrentInstant();
+            Instant endDate = startDate.Plus(Duration.FromHours(1));
+            string location = s_faker.Address.FullAddress();
+            IReadOnlyList<Attendee> attendees = [];
+            string creatorId = "system";
+
+            // Act
+            AppointmentCreated appointmentCreated = new(appointmentId, startDate, endDate, location, attendees, creatorId);
+
+            // Assert
+            appointmentCreated.Attendees.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Preserve_start_and_end_dates_in_UTC()
+        {
+            // Arrange
+            AppointmentId appointmentId = AppointmentId.New();
+            Instant startDate = Instant.FromUtc(2026, 5, 15, 10, 30, 0);
+            Instant endDate = Instant.FromUtc(2026, 5, 15, 12, 0, 0);
+            string location = s_faker.Address.FullAddress();
+            IReadOnlyList<Attendee> attendees = [];
+            string creatorId = "system";
+
+            // Act
+            AppointmentCreated appointmentCreated = new(appointmentId, startDate, endDate, location, attendees, creatorId);
+
+            // Assert
+            appointmentCreated.StartDate.Should().Be(startDate);
+            appointmentCreated.EndDate.Should().Be(endDate);
+            appointmentCreated.StartDate.ToDateTimeUtc().Should().Be(new DateTime(2026, 5, 15, 10, 30, 0));
+            appointmentCreated.EndDate.ToDateTimeUtc().Should().Be(new DateTime(2026, 5, 15, 12, 0, 0));
+        }
+    }
+}


### PR DESCRIPTION
## 📋 Description

Implements the publication of `AppointmentCreated` event whenever a new appointment is created. This event notifies external subscribers about the creation of appointments with complete details including dates, location, attendees, and creator information.

## 🎯 Issue

Closes #329

## 📝 Changes

### New Files

1. **`src/Agenda.Events/AppointmentCreated.cs`**
   - Core event class extending `Paramore.Brighter.Event`
   - Properties: `AppointmentId`, `StartDate`, `EndDate` (ISO-8601 UTC via NodaTime.Instant), `Location`, `Attendees`, `CreatorId`
   - Comprehensive validation: null checks on required fields with `ArgumentNullException`
   - Supports edge cases: empty location, empty attendees list

2. **`tests/Agenda.API.UnitTests/Features/Events/AppointmentCreatedShould.cs`**
   - 7 comprehensive unit tests for the `AppointmentCreated` event class
   - Coverage:
     - Happy path: successful event creation with all data
     - Null validation: location, attendees, creatorId
     - Edge cases: empty location, empty attendees list
     - UTC preservation: StartDate/EndDate in ISO-8601 format

### Modified Files

1. **`src/Agenda.API/Features/Appointments/v1/Create/CreateAppointmentEndpoint.cs`**
   - Enhanced `HandleAsync()` method to emit `AppointmentCreated` event
   - Event published via `CommandProcessor.DepositPostAsync()` alongside existing `AppointmentScheduled` event
   - CreatorId set to "system" by default
   - Attendees mapped with `FirstName`/`LastName` properties

2. **`tests/Agenda.API.UnitTests/Features/Appointments/v1/Create/CreateAppointementEndpointShould.cs`**
   - Enhanced with 4 new comprehensive test methods:
     - `Emit_AppointmentCreated_event_with_correct_data_when_appointment_is_created`: Full data validation
     - `Include_all_attendees_in_AppointmentCreated_event`: Multiple attendees mapping
     - `Emit_AppointmentCreated_event_with_empty_location_when_no_location_provided`: Edge case
     - `Emit_AppointmentCreated_event_with_empty_attendees_list_when_none_provided`: Edge case
   - All tests use FakeItEasy mocking in strict mode with precise assertion patterns

3. **`Directory.Packages.props`**
   - Added `NodaTime` version 3.3.2 for ISO-8601 UTC date handling

4. **`CHANGELOG.md`**
   - Added feature entry in Unreleased section under API features

5. **`.gitignore`**
   - Added `.devcontainer/devcontainer-lock.json` pattern

## ✅ Quality Assurance

- [x] Code compiles with zero errors
- [x] All unit tests pass (7 tests in AppointmentCreatedShould.cs)
- [x] All integration tests pass (4 new event emission tests in CreateAppointementEndpointShould.cs)
- [x] Follows vertical-slice architecture patterns
- [x] Respects .editorconfig formatting standards
- [x] Comprehensive test coverage including edge cases
- [x] Dependencies properly managed (NodaTime added to Directory.Packages.props)
- [x] CHANGELOG documented

## 🔍 Key Implementation Details

### Event Emission
- Uses existing `CommandProcessor.DepositPostAsync()` pattern
- Emits alongside `AppointmentScheduled` event for consistency
- Non-blocking: event publishing doesn't affect appointment creation response

### Date Handling
- Leverages `NodaTime.Instant` for proper ISO-8601 UTC compliance
- Eliminates timezone ambiguity and ensures consistency across time zones

### Creator ID
- Currently hardcoded as "system"
- Future enhancement: extract from HTTP context/claims if needed

### Test Coverage
- Unit tests: Event class validation and constraints
- Integration tests: Endpoint behavior and event emission verification
- Edge case testing: Empty location, empty attendees list, null validation

## 📊 Commits

| Commit | Message |
|--------|---------|
| b3eb0c4 | feat(events): create AppointmentCreated event class |
| 2f67f29 | feat(endpoints): integrate AppointmentCreated event emission in CreateAppointmentEndpoint |
| 58ea60d | test(events): add comprehensive unit tests for AppointmentCreated event |
| a7e8b2d | test(endpoints): add event emission tests to CreateAppointmentEndpoint |
| f1c9d3a | docs: update CHANGELOG with AppointmentCreated event feature |
| a41c0a7 | test(events): enhance AppointmentCreated event emission test coverage |

## 🚀 Ready for Review

All work is feature-complete and ready for code review. The implementation follows project conventions and maintains backward compatibility.
