### PR TITLE
fix(apphost): unblock postgres and messaging startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added task issue template
 - Updated bug issue template
 - Added Codecov configuration file
+- Fixed Aspire AppHost resource startup blocking by removing custom TCP health checks wired to PostgreSQL and RabbitMQ resources
 - Fixed devcontainer .NET SDK provisioning to install `10.0.300` by default (with `10.0.203` and `10.0.201` as additional SDKs) to match project requirements and unblock Aspire startup
 - Fixed integration test startup hangs by restoring the AppHost/fixture startup flow used on `develop` for integration mode
 - Stabilized appointment creation integration coverage by retrying transient `5xx` responses during startup races

--- a/src/Agenda.AppHost/AppHost.cs
+++ b/src/Agenda.AppHost/AppHost.cs
@@ -1,9 +1,5 @@
-using System.Data.Common;
-using System.Net.Sockets;
 using Aspire.Hosting;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Projects;
 
 IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder(args);
@@ -11,28 +7,8 @@ IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder(ar
 bool isRunningIntegrationTests = builder.Configuration.GetValue(RunningIntegrationTestsConfigName, false);
 bool shouldTrackResourceHealth = !isRunningIntegrationTests;
 
-if (shouldTrackResourceHealth)
-{
-    IHealthChecksBuilder healthChecksBuilder = builder.Services.AddHealthChecks();
-    healthChecksBuilder.AddCheck(
-        "postgres",
-        new ConnectionStringTcpHealthCheck(builder.Configuration, "postgres", ConnectionType.Postgres),
-        HealthStatus.Unhealthy,
-        ["ready"]);
-    healthChecksBuilder.AddCheck(
-        "messaging",
-        new ConnectionStringTcpHealthCheck(builder.Configuration, "messaging", ConnectionType.Uri),
-        HealthStatus.Unhealthy,
-        ["ready"]);
-}
-
 var postgres = builder.AddPostgres("postgres")
     .WithImage("postgres:17-alpine");
-
-if (shouldTrackResourceHealth)
-{
-    postgres = postgres.WithHealthCheck("postgres");
-}
 
 if (builder.ExecutionContext.IsRunMode && !isRunningIntegrationTests)
 {
@@ -43,11 +19,6 @@ if (builder.ExecutionContext.IsRunMode && !isRunningIntegrationTests)
 
 var messaging = builder.AddRabbitMQ("messaging")
     .WithManagementPlugin();
-
-if (shouldTrackResourceHealth)
-{
-    messaging = messaging.WithHealthCheck("messaging");
-}
 
 IResourceBuilder<ProjectResource> migrationService = builder.AddProject<Agenda_Migrator>("migrations")
     .WithReference(postgres)
@@ -91,98 +62,4 @@ builder.Build().Run();
 public partial class Program
 {
     public const string RunningIntegrationTestsConfigName = "RunningIntegrationTests";
-}
-
-internal enum ConnectionType
-{
-    Postgres,
-    Uri
-}
-
-internal sealed class ConnectionStringTcpHealthCheck : IHealthCheck
-{
-    private readonly IConfiguration _configuration;
-    private readonly string _connectionName;
-    private readonly ConnectionType _connectionType;
-
-    public ConnectionStringTcpHealthCheck(IConfiguration configuration, string connectionName, ConnectionType connectionType)
-    {
-        _configuration = configuration;
-        _connectionName = connectionName;
-        _connectionType = connectionType;
-    }
-
-    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
-    {
-        string connectionString = _configuration.GetConnectionString(_connectionName) ?? string.Empty;
-
-        if (string.IsNullOrWhiteSpace(connectionString))
-        {
-            return HealthCheckResult.Unhealthy($"Connection string '{_connectionName}' is missing.");
-        }
-
-        bool canExtractEndpoint = TryGetEndpoint(connectionString, _connectionType, out string host, out int port);
-
-        if (!canExtractEndpoint)
-        {
-            return HealthCheckResult.Unhealthy($"Connection string '{_connectionName}' does not contain a valid endpoint.");
-        }
-
-        using TcpClient tcpClient = new();
-
-        try
-        {
-            using CancellationTokenSource timeoutCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            timeoutCancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(2));
-
-            await tcpClient.ConnectAsync(host, port, timeoutCancellationTokenSource.Token);
-            return HealthCheckResult.Healthy();
-        }
-        catch (Exception exception)
-        {
-            return HealthCheckResult.Unhealthy(exception.Message, exception);
-        }
-    }
-
-    private static bool TryGetEndpoint(string connectionString, ConnectionType connectionType, out string host, out int port)
-    {
-        host = string.Empty;
-        port = connectionType == ConnectionType.Postgres ? 5432 : 5672;
-
-        if (connectionType == ConnectionType.Uri)
-        {
-            if (!Uri.TryCreate(connectionString, UriKind.Absolute, out Uri uri) || string.IsNullOrWhiteSpace(uri.Host))
-            {
-                return false;
-            }
-
-            host = uri.Host;
-            port = uri.Port > 0 ? uri.Port : 5672;
-            return true;
-        }
-
-        DbConnectionStringBuilder connectionStringBuilder = new() { ConnectionString = connectionString };
-
-        bool hasHost = connectionStringBuilder.TryGetValue("Host", out object? hostValue)
-            || connectionStringBuilder.TryGetValue("Server", out hostValue);
-
-        if (!hasHost)
-        {
-            return false;
-        }
-
-        host = hostValue?.ToString() ?? string.Empty;
-
-        if (string.IsNullOrWhiteSpace(host))
-        {
-            return false;
-        }
-
-        if (!connectionStringBuilder.TryGetValue("Port", out object? portValue))
-        {
-            return true;
-        }
-
-        return int.TryParse(portValue?.ToString(), out port);
-    }
 }


### PR DESCRIPTION
## Summary
- remove custom TCP health checks in AppHost for postgres and messaging resources
- remove resource-level health check wiring that could keep resources unhealthy in Aspire startup flow
- update changelog with the AppHost startup fix

## Validation
- dotnet build src/Agenda.AppHost/Agenda.AppHost.csproj