### PR TITLE
feat(api): update appointments HATEOAS headers contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added publication of `AppointmentScheduled` event when a new appointment is scheduled : 
 - Added publication of `AppointmentCreated` event when a new appointment is created, containing appointment ID, start/end dates (ISO 8601), location, attendees list, and creator ID (#329)
 - Added healthchecks for PostgreSQL and RabbitMQ
-- Fixed appointments listing pagination metadata for UI navigation (`total` now represents total pages, with explicit `totalCount` and `pageSize` fields)
+- Updated appointments paginated headers contract for UI navigation: `total` now represents the total number of matching elements, `count` represents the number of elements in the current page, and redundant `totalCount` was removed
 - Added multi-criteria filtering for appointments listing (`subject`, `location`, and `from`/`to` time range)
 - Fixed appointments search query binding for ISO `OffsetDateTime` range filters so first-load requests return `200` instead of `400`
-- Added `HEAD` support headers on appointments `GET` endpoints: browsable resources now emit `Link`, and paginated collections emit `Link`, `total`, `totalCount`, and `count` headers
+- Added `HEAD` support headers on appointments `GET` endpoints: `Link` remains the navigation header, and paginated collections emit `Link`, `total`, and `count` headers
 - Added integration coverage for appointments `HEAD` contracts on `GET /appointments/{id}` and paginated `GET /appointments` responses
 - Made appointments search case-insensitive at database level by switching `Subject` and `Location` to PostgreSQL `citext` columns ([#504](https://github.com/candoumbe/agenda/issues/504))
 

--- a/src/Agenda.API/Features/AddLinkHeaderResponseInterceptor.cs
+++ b/src/Agenda.API/Features/AddLinkHeaderResponseInterceptor.cs
@@ -49,12 +49,11 @@ public partial class AddLinkHeaderResponseInterceptor : IResponseInterceptor
 
             if (hasSuccessfulStatusCode && TryGetOkValue(response, out object value))
             {
-                bool hasPageInformation = TryGetPageInformation(value, out long total, out long totalCount, out long count, out List<Link> pageLinks);
+                bool hasPageInformation = TryGetPageInformation(value, out long total, out long count, out List<Link> pageLinks);
                 if (hasPageInformation)
                 {
                     SetLinkHeader(ctx, pageLinks);
                     ctx.Response.Headers["total"] = total.ToString(CultureInfo.InvariantCulture);
-                    ctx.Response.Headers["totalCount"] = totalCount.ToString(CultureInfo.InvariantCulture);
                     ctx.Response.Headers["count"] = count.ToString(CultureInfo.InvariantCulture);
                 }
                 else
@@ -98,10 +97,9 @@ public partial class AddLinkHeaderResponseInterceptor : IResponseInterceptor
         return hasValue;
     }
 
-    private static bool TryGetPageInformation(object value, out long total, out long totalCount, out long count, out List<Link> links)
+    private static bool TryGetPageInformation(object value, out long total, out long count, out List<Link> links)
     {
         total = 0;
-        totalCount = 0;
         count = 0;
         links = [];
 
@@ -111,26 +109,23 @@ public partial class AddLinkHeaderResponseInterceptor : IResponseInterceptor
             return false;
         }
 
-        PropertyInfo totalProperty = valueType.GetProperty(nameof(PageOf<Browsable<object>>.Total));
         PropertyInfo totalCountProperty = valueType.GetProperty(nameof(PageOf<Browsable<object>>.TotalCount));
         PropertyInfo countProperty = valueType.GetProperty(nameof(PageOf<Browsable<object>>.Count));
         PropertyInfo linksProperty = valueType.GetProperty(nameof(PageOf<Browsable<object>>.Links));
 
-        if (totalProperty is null || totalCountProperty is null || countProperty is null || linksProperty is null)
+        if (totalCountProperty is null || countProperty is null || linksProperty is null)
         {
             return false;
         }
 
-        object totalValue = totalProperty.GetValue(value);
         object totalCountValue = totalCountProperty.GetValue(value);
         object countValue = countProperty.GetValue(value);
-        if (totalValue is null || totalCountValue is null || countValue is null)
+        if (totalCountValue is null || countValue is null)
         {
             return false;
         }
 
-        total = Convert.ToInt64(totalValue, CultureInfo.InvariantCulture);
-        totalCount = Convert.ToInt64(totalCountValue, CultureInfo.InvariantCulture);
+        total = Convert.ToInt64(totalCountValue, CultureInfo.InvariantCulture);
         count = Convert.ToInt64(countValue, CultureInfo.InvariantCulture);
 
         object rawLinks = linksProperty.GetValue(value);

--- a/src/Agenda.API/Features/Appointments/v1/Search/SearchAppointmentsEndpoint.cs
+++ b/src/Agenda.API/Features/Appointments/v1/Search/SearchAppointmentsEndpoint.cs
@@ -154,8 +154,7 @@ public class SearchAppointmentsEndpoint : Endpoint<SearchAppointmentRequest, Ok<
 
         static void AddPaginationHeaders(HttpResponse response, PageOf<Browsable<AppointmentInfo>> page)
         {
-            response.Headers["total"] = page.Total.ToString(CultureInfo.InvariantCulture);
-            response.Headers["totalCount"] = page.TotalCount.ToString(CultureInfo.InvariantCulture);
+            response.Headers["total"] = page.TotalCount.ToString(CultureInfo.InvariantCulture);
             response.Headers["count"] = page.Count.ToString(CultureInfo.InvariantCulture);
 
             if (page.Links is null)

--- a/tests/Agenda.API.IntegrationTests/Appointments/v1/Search/SearchAppointmentHeadContractShould.cs
+++ b/tests/Agenda.API.IntegrationTests/Appointments/v1/Search/SearchAppointmentHeadContractShould.cs
@@ -59,10 +59,9 @@ public sealed class SearchAppointmentHeadContractShould
         HttpResponseHeaders headers = headResponse.Headers;
         headers.Should().ContainKey("total")
             .WhoseValue.Should().ContainSingle("3");
-        headers.Should().ContainKey("totalCount")
-            .WhoseValue.Should().ContainSingle("3");
         headers.Should().ContainKey("count")
             .WhoseValue.Should().ContainSingle("2");
+        headers.Should().NotContainKey("totalCount");
 
         headers.Should().ContainKey("Link")
             .WhoseValue.Should().ContainSingle(link => link.Contains("rel=\"first\"", StringComparison.OrdinalIgnoreCase))
@@ -103,7 +102,6 @@ public sealed class SearchAppointmentHeadContractShould
 
         string expectedCount = root.GetProperty("count").GetInt64().ToString(CultureInfo.InvariantCulture);
         string expectedTotal = root.GetProperty("total").GetInt64().ToString(CultureInfo.InvariantCulture);
-        string expectedTotalCount = root.GetProperty("totalCount").GetInt64().ToString(CultureInfo.InvariantCulture);
         string expectedFirstRelation = "rel=\"first\"";
         string expectedLastRelation = "rel=\"last\"";
 
@@ -111,8 +109,7 @@ public sealed class SearchAppointmentHeadContractShould
             .WhoseValue.Should().ContainSingle(expectedCount);
         getResponse.Headers.Should().ContainKey("total")
             .WhoseValue.Should().ContainSingle(expectedTotal);
-        getResponse.Headers.Should().ContainKey("totalCount")
-            .WhoseValue.Should().ContainSingle(expectedTotalCount);
+        getResponse.Headers.Should().NotContainKey("totalCount");
         getResponse.Headers.Should().ContainKey("Link")
             .WhoseValue.Should().ContainSingle(link => link.Contains(expectedFirstRelation, StringComparison.OrdinalIgnoreCase))
             .And.ContainSingle(link => link.Contains(expectedLastRelation, StringComparison.OrdinalIgnoreCase));
@@ -121,8 +118,7 @@ public sealed class SearchAppointmentHeadContractShould
             .WhoseValue.Should().ContainSingle(expectedCount);
         headResponse.Headers.Should().ContainKey("total")
             .WhoseValue.Should().ContainSingle(expectedTotal);
-        headResponse.Headers.Should().ContainKey("totalCount")
-            .WhoseValue.Should().ContainSingle(expectedTotalCount);
+        headResponse.Headers.Should().NotContainKey("totalCount");
         headResponse.Headers.Should().ContainKey("Link")
             .WhoseValue.Should().ContainSingle(link => link.Contains(expectedFirstRelation, StringComparison.OrdinalIgnoreCase))
             .And.ContainSingle(link => link.Contains(expectedLastRelation, StringComparison.OrdinalIgnoreCase));

--- a/tests/Agenda.API.UnitTests/Features/Appointments/v1/Search/AddLinkHeaderResponseInterceptorShould.cs
+++ b/tests/Agenda.API.UnitTests/Features/Appointments/v1/Search/AddLinkHeaderResponseInterceptorShould.cs
@@ -97,10 +97,9 @@ public class AddLinkHeaderResponseInterceptorShould
 
         headers.Should().ContainKey("total")
             .WhoseValue.Should().ContainSingle("0");
-        headers.Should().ContainKey("totalCount")
-            .WhoseValue.Should().ContainSingle("0");
         headers.Should().ContainKey("count")
             .WhoseValue.Should().ContainSingle("0");
+        headers.Should().NotContainKey("totalCount");
 
     }
 


### PR DESCRIPTION
## Summary
- update appointments HATEOAS pagination headers contract
- `total` now returns total number of matching elements
- keep `count` as number of elements in current page
- keep `Link` as HATEOAS navigation header
- remove redundant `totalCount` header
- update unit and integration tests
- update changelog

## Validation
- dotnet test tests/Agenda.API.UnitTests/Agenda.API.UnitTests.csproj -- --filter-class "*AddLinkHeaderResponseInterceptorShould"
- dotnet test tests/Agenda.API.IntegrationTests/Agenda.API.IntegrationTests.csproj -- --filter-class "*SearchAppointmentHeadContractShould"
