### PR TITLE
feat(frontend): add homepage, result counter and cancel navigation

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -39,3 +39,6 @@ Initial setup complete.
 
 ## Learning — 2026-05-28T00:00:00Z: Single-entry/single-exit refactor in response interceptor
 For `AddLinkHeaderResponseInterceptor`, a safe single-entry/single-exit refactor can be applied by replacing early returns with explicit guard booleans and structured branching in `InterceptResponseAsync`, while keeping helper behavior and header output unchanged. Targeted xUnit class filtering via MTP-compatible arguments (`-- --filter-class`) validates behavior without broad test execution.
+
+## Learning — 2026-05-28T20:09:00Z: HATEOAS link query parameter case mismatch risk
+When backend-generated pagination links use PascalCase query names (for example `Page`, `PageSize`) and frontend extraction expects lowercase keys, browser `URLSearchParams` returns null because key lookup is case-sensitive. Frontend parsing should check both variants where compatibility is required to prevent pagination state drift.

--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -38,3 +38,28 @@ Initial setup complete.
 - Implemented issue #541 behavior in appointments listing with default 15-day interval initialization and empty-range fallback discovery query.
 - Added jump-to-first-incoming flow that shifts the interval to the discovered appointment start and reloads list data.
 - Frontend validation completed with successful build and test execution for the updated behavior.
+
+### 2026-05-28: Pagination + HATEOAS header alignment
+
+- The Angular `ApiService` now reads pagination/HATEOAS metadata from response headers (`Link`, `total`, `count`) and merges it with the legacy body contract.
+- Link parsing must support both `rel="previous"` and `rel="prev"` and normalize to the frontend `links.previous` property for stable list-page navigation.
+- For robustness, total pages should prioritize HATEOAS-derived values (`links.last` or `total` header + page size) before the legacy `body.total` value.
+- Updated files: `src/Agenda.Frontend/src/services/api-service.ts`, `src/Agenda.Frontend/src/services/api-service.spec.ts`, `src/Agenda.Frontend/src/models/page-of.ts`.
+- Pagination link query parsing should support both camelCase and PascalCase key variants (`page`/`Page`) because browser URL parsing is case-sensitive while backend-generated links may use PascalCase.
+
+### 2026-05-28: HEAD counter, Homepage, Attendees stub
+
+- Added `countAppointments(params)` to `ApiService` — makes HEAD to `/api/appointments`, returns `Observable<number>` from `total` response header; returns 0 when header absent.
+- Added `totalResultsCount = signal<number | null>(null)` and `hasCountError = signal(false)` to `AppointmentsListPageComponent`; HEAD fires in parallel with GET inside `loadAppointments` (not sequential).
+- The results count badge is always visible in the list page (loading state → "Chargement…", error → "Résultats non disponibles", resolved → "X résultat(s) trouvé(s)").
+- Created `HomePageComponent` (3 navigation cards — primary gradient to `/appointments`, accent gradient to `/appointments/new`, tertiary gradient to `/attendees`); route `''` now points to the homepage instead of a redirect.
+- Created `AttendeesSearchPageComponent` stub — search form (name + email) renders with a "Fonctionnalité à venir" placeholder; route `/attendees` registered in `app.routes.ts`.
+- All existing tests remain green (30/30 list-page, 13/13 api-service); new tests added: 2 for HEAD counter in list-page spec, 10 for homepage spec (100 % coverage on homepage).
+- When adding `countAppointments` to the component spy, update the spy type declaration AND the `beforeEach` mock in the spec file — otherwise existing tests fail at runtime.
+
+### 2026-05-29: Schedule appointment cancel navigation
+
+- Added a cancel action to the schedule appointment page with conditional confirmation based on unsaved form input.
+- Updated the component, template, stylesheet, and spec together to keep the UX and test coverage aligned.
+- Validation reported by Dallas: targeted schedule-appointment-page test passed and `npm run build` passed.
+- Delivery commit: `ec44a3ce1a1e00c8ca01e592ab76fea4757d1a60`.

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -21,6 +21,7 @@ Agent Scribe initialized and ready for work.
 📌 Logged and consolidated AssemblyFixture migration coordination artifacts on 2026-05-26
 📌 Logged issue #545 orchestration batch and session record on 2026-05-24
 📌 Logged Bishop single-entry/single-exit refactor batch and merged directive inbox on 2026-05-28
+📌 Logged Dallas frontend pagination/HATEOAS batch and merged decision inbox on 2026-05-28
 
 ## Learnings
 
@@ -30,3 +31,10 @@ Initial setup complete.
 - Coordination closes faster when per-agent orchestration logs, decision deduplication, and history updates are completed in one pass.
 - If `.squad/decisions/inbox/` is empty, record an explicit no-op merge note in the session log to keep audit continuity.
 - When a style directive is repeated with stronger wording, keep the stronger statement in `decisions.md` and clean inbox immediately.
+- When frontend pagination contracts evolve from body metadata to response headers, capture both the metadata source-of-truth decision and compatibility parsing constraints in `decisions.md`.
+
+### 2026-05-29: Logged schedule cancel navigation batch
+
+- Recorded Dallas' frontend change for schedule-page cancel navigation in both orchestration and session logs.
+- Merged the remaining Dallas inbox entry covering homepage routing, HEAD count retrieval, and attendees stub registration into `decisions.md`.
+- Cross-agent history should capture validation evidence when the agent reports both targeted tests and build status, even if the Squad task itself is documentation-only.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -124,6 +124,25 @@ Jump action updates `from` to the discovered appointment start date and `to` to 
 **What:** When the team writes code, always use the single entry / single exit approach.
 **Why:** User request - captured for team memory.
 
+### 2026-05-28T20:08:30Z: Frontend pagination should prioritize HATEOAS headers
+**By:** Dallas
+**What:** Frontend pagination/navigation metadata should be resolved from HTTP response headers first (`Link`, `total`, `count`) and only fallback to legacy body pagination fields when headers are absent.
+**Why:** The backend now emits canonical HATEOAS/count metadata in headers; header-first parsing avoids stale or partial body metadata.
+
+### 2026-05-28T20:09:00Z: Frontend pagination link parser must support parameter case variants
+**By:** Bishop
+**What:** Frontend extraction of pagination query values from HATEOAS links must handle both lowercase and PascalCase query parameter names (for example `page` and `Page`) when reading link URLs.
+**Why:** `URLSearchParams` is case-sensitive and backend-generated links may use PascalCase, which can otherwise force incorrect page fallback behavior.
+
+### 2026-05-28: Homepage route and HEAD counter pattern
+**By:** Dallas
+**What:**
+- Route `''` now loads `HomePageComponent` directly (no more `redirectTo: 'appointments'`).
+- `ApiService.countAppointments()` uses HTTP HEAD to retrieve the `total` header independently of GET — both calls fire in parallel in `AppointmentsListPageComponent.loadAppointments()`.
+- Route `/attendees` added and served by `AttendeesSearchPageComponent` (stub).
+**Why:** User request — three distinct frontend features shipped atomically.
+**Impact:** Entry URL lands on the new homepage; appointments list shows a persistent result count badge; attendees route is registered for future implementation.
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/.squad/skills/frontend-pagination-from-api-metadata/SKILL.md
+++ b/.squad/skills/frontend-pagination-from-api-metadata/SKILL.md
@@ -11,8 +11,13 @@ Keep displayed page numbers and next/previous behavior strictly aligned with bac
 ## Recommended approach
 
 1. Treat `response.page` as the source of truth for current page display.
-2. Derive `totalPages` from `links.last` page query param when present.
-3. Fallback to `response.total` only when `links.last` is absent.
+2. Prefer HATEOAS headers as canonical metadata when available:
+	- `Link` header for navigation relations (`first`, `last`, `next`, `previous`/`prev`)
+	- `total` header for total item count
+	- `count` header for current page item count
+3. Derive `totalPages` from `links.last` page query param when present.
+4. Fallback to computing `totalPages` from headers (`ceil(total/pageSize)`) when `links.last` is absent.
+5. Use `response.total` only as a final legacy fallback when no header-derived metadata is usable.
 4. Enable/disable previous/next actions from `links.previous` and `links.next` first, with numeric fallback (`currentPage` vs `totalPages`) only if links are absent.
 5. Parse next/previous page targets from links when possible to avoid optimistic client-side drift.
 
@@ -24,6 +29,8 @@ Keep displayed page numbers and next/previous behavior strictly aligned with bac
 ## Testing checklist
 
 - Current page display mirrors `response.page`.
+- Header-only Link metadata is correctly mapped to frontend links.
+- `rel="prev"` is normalized to the same behavior as `rel="previous"`.
 - Total pages follow `links.last` when `response.total` is inconsistent.
 - Next/previous buttons honor link availability.
 - Search criteria changes trigger page reset to 1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added appointments list page with card-based layout, date grouping, search by subject, and pagination (#502)
 - Added automatic redirect to appointments list after creating a new appointment (#502)
 - Added default 15-day appointments window with contextual empty-state guidance and jump-to-first-incoming action ([#541](https://github.com/candoumbe/agenda/issues/541))
+- Added a homepage with navigation cards for the agenda, new appointment creation, and participant search
+- Added a live appointment result counter powered by `HEAD /appointments`, visible even when no items are returned
+- Added a cancellable appointment creation flow with dirty-form confirmation before leaving the page
+- Added a participants search page stub as the first entry point for attendee lookup
 
 #### API
 - Added `DELETE /appointments/{id}/attendees/{id}` endpoint

--- a/src/Agenda.API/Features/Appointments/AbstractSearchRequest.cs
+++ b/src/Agenda.API/Features/Appointments/AbstractSearchRequest.cs
@@ -10,7 +10,7 @@ public abstract record AbstractSearchRequest<T>
     /// <summary>
     /// Index of the page
     /// </summary>
-    public NonNegativeInteger Page { get; init; }
+    public NonNegativeInteger Page { get; init; } = NonNegativeInteger.One;
 
     /// <summary>
     /// Defines the number of items the result set will contain at most.
@@ -18,10 +18,10 @@ public abstract record AbstractSearchRequest<T>
     /// <remarks>
     /// This value is just a hint that the server may not fulfill. The server may return fewer items depending on its configuration.
     /// </remarks>
-    public PositiveInteger PageSize { get; init; }
+    public PositiveInteger PageSize { get; init; } = PositiveInteger.From(10);
 
     /// <summary>
     /// Directive on how to sort results
     /// </summary>
-    public string Sort { get; init; }
+    public string Sort { get; init; } = string.Empty;
 }

--- a/src/Agenda.Frontend/src/app/app.routes.ts
+++ b/src/Agenda.Frontend/src/app/app.routes.ts
@@ -1,12 +1,14 @@
 import { Routes } from '@angular/router';
 import { ScheduleAppointmentPageComponent } from './pages/schedule-appointment-page/schedule-appointment-page.component';
 import { AppointmentsListPageComponent } from './pages/appointments-list-page/appointments-list-page.component';
+import { HomePageComponent } from './pages/home-page/home-page.component';
+import { AttendeesSearchPageComponent } from './pages/attendees-search-page/attendees-search-page.component';
 
 export const routes: Routes = [
   {
     path: '',
     pathMatch: 'full',
-    redirectTo: 'appointments'
+    component: HomePageComponent
   },
   {
     path: 'appointments',
@@ -15,5 +17,9 @@ export const routes: Routes = [
   {
     path: 'appointments/new',
     component: ScheduleAppointmentPageComponent
+  },
+  {
+    path: 'attendees',
+    component: AttendeesSearchPageComponent
   }
 ];

--- a/src/Agenda.Frontend/src/app/pages/appointments-list-page/appointments-list-page.component.css
+++ b/src/Agenda.Frontend/src/app/pages/appointments-list-page/appointments-list-page.component.css
@@ -98,6 +98,24 @@
   width: 100%;
 }
 
+.results-count-badge {
+  display: inline-block;
+  margin-bottom: 1rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: 1px solid #bfdbfe;
+}
+
+.results-count-badge.count-error {
+  background: #f9fafb;
+  color: #9ca3af;
+  border-color: #e5e7eb;
+}
+
 .loading {
   text-align: center;
   padding: 3rem 1rem;

--- a/src/Agenda.Frontend/src/app/pages/appointments-list-page/appointments-list-page.component.html
+++ b/src/Agenda.Frontend/src/app/pages/appointments-list-page/appointments-list-page.component.html
@@ -58,6 +58,16 @@
       + Nouveau rendez-vous
     </button>
 
+    <div class="results-count-badge" [class.count-error]="hasCountError()">
+      @if (hasCountError()) {
+        <span>Résultats non disponibles</span>
+      } @else if (totalResultsCount() === null) {
+        <span>Chargement...</span>
+      } @else {
+        <span>{{ totalResultsCount() }} résultat(s) trouvé(s)</span>
+      }
+    </div>
+
     @if (hasError()) {
       <p class="feedback failure">{{ errorMessage() }}</p>
     }

--- a/src/Agenda.Frontend/src/app/pages/appointments-list-page/appointments-list-page.component.spec.ts
+++ b/src/Agenda.Frontend/src/app/pages/appointments-list-page/appointments-list-page.component.spec.ts
@@ -25,7 +25,7 @@ function toDateValue(date: Date): string {
 describe('AppointmentsListPageComponent', () => {
   let component: AppointmentsListPageComponent;
   let fixture: ComponentFixture<AppointmentsListPageComponent>;
-  let apiServiceSpy: { getAppointments: ReturnType<typeof vi.fn> };
+  let apiServiceSpy: { getAppointments: ReturnType<typeof vi.fn>; countAppointments: ReturnType<typeof vi.fn> };
   let routerSpy: { navigate: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
@@ -36,7 +36,8 @@ describe('AppointmentsListPageComponent', () => {
         count: 1,
         items: [],
         links: {}
-      }))
+      })),
+      countAppointments: vi.fn().mockReturnValue(of(0))
     };
 
     routerSpy = {
@@ -956,5 +957,53 @@ describe('AppointmentsListPageComponent', () => {
     expect(component.searchForm.controls.toDate.value).toBe(toDateValue(new Date('2026-05-16T08:00:00Z')));
     expect(component.searchForm.controls.fromTime.value).toBe('');
     expect(component.searchForm.controls.toTime.value).toBe('');
+  });
+
+  it('should call countAppointments in parallel with getAppointments and expose the total count', () => {
+    // Arrange
+    const mockResponse: PageOf<Browsable<Appointment>> = {
+      page: 1,
+      total: 1,
+      count: 2,
+      items: [],
+      links: {}
+    };
+
+    apiServiceSpy.getAppointments.mockReturnValue(of(mockResponse));
+    apiServiceSpy.countAppointments.mockReturnValue(of(42));
+
+    // Act
+    fixture.detectChanges();
+
+    // Assert
+    expect(apiServiceSpy.countAppointments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        page: 1,
+        pageSize: 10
+      })
+    );
+    expect(component.totalResultsCount()).toBe(42);
+    expect(component.hasCountError()).toBe(false);
+  });
+
+  it('should set hasCountError when countAppointments fails', () => {
+    // Arrange
+    const mockResponse: PageOf<Browsable<Appointment>> = {
+      page: 1,
+      total: 1,
+      count: 0,
+      items: [],
+      links: {}
+    };
+
+    apiServiceSpy.getAppointments.mockReturnValue(of(mockResponse));
+    apiServiceSpy.countAppointments.mockReturnValue(throwError(() => new Error('HEAD failed')));
+
+    // Act
+    fixture.detectChanges();
+
+    // Assert
+    expect(component.totalResultsCount()).toBeNull();
+    expect(component.hasCountError()).toBe(true);
   });
 });

--- a/src/Agenda.Frontend/src/app/pages/appointments-list-page/appointments-list-page.component.ts
+++ b/src/Agenda.Frontend/src/app/pages/appointments-list-page/appointments-list-page.component.ts
@@ -42,6 +42,8 @@ export class AppointmentsListPageComponent implements OnInit {
   public hasError = signal(false);
   public errorMessage = signal('');
   public firstIncomingAppointmentOutsideInterval = signal<Browsable<Appointment> | null>(null);
+  public totalResultsCount = signal<number | null>(null);
+  public hasCountError = signal(false);
 
   public readonly searchForm = this._formBuilder.nonNullable.group({
     subject: [''],
@@ -78,6 +80,8 @@ export class AppointmentsListPageComponent implements OnInit {
     this.isLoading.set(true);
     this.hasError.set(false);
     this.errorMessage.set('');
+    this.totalResultsCount.set(null);
+    this.hasCountError.set(false);
 
     const targetPage = this.normalizePage(page ?? this.currentPage());
     const filters = this.buildFilters();
@@ -90,6 +94,17 @@ export class AppointmentsListPageComponent implements OnInit {
       from: filters.from,
       to: filters.to
     };
+
+    this._apiService.countAppointments(searchParams)
+      .pipe(takeUntilDestroyed(this._destroyRef))
+      .subscribe({
+        next: (count) => {
+          this.totalResultsCount.set(count);
+        },
+        error: () => {
+          this.hasCountError.set(true);
+        }
+      });
 
     this._apiService.getAppointments(searchParams)
       .pipe(

--- a/src/Agenda.Frontend/src/app/pages/attendees-search-page/attendees-search-page.component.css
+++ b/src/Agenda.Frontend/src/app/pages/attendees-search-page/attendees-search-page.component.css
@@ -1,0 +1,124 @@
+.attendees-page {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  padding: 2rem 1rem;
+}
+
+.glow {
+  position: absolute;
+  pointer-events: none;
+  opacity: 0.3;
+}
+
+.glow-left {
+  top: 20%;
+  left: -10%;
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(circle, #3b82f6, transparent);
+  filter: blur(80px);
+}
+
+.glow-right {
+  bottom: 20%;
+  right: -10%;
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(circle, #8b5cf6, transparent);
+  filter: blur(80px);
+}
+
+.card {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 800px;
+  background: white;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.page-header .kicker {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #6b7280;
+  margin: 0 0 0.5rem 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.page-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem 0;
+  color: #1f2937;
+}
+
+.page-header .subtitle {
+  font-size: 1rem;
+  color: #6b7280;
+  margin: 0;
+}
+
+.search-section {
+  margin-bottom: 2rem;
+}
+
+.search-form {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.search-input {
+  flex: 1;
+  min-width: 200px;
+  padding: 0.75rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.coming-soon {
+  text-align: center;
+  padding: 3rem 1rem;
+  border: 2px dashed #e5e7eb;
+  border-radius: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.coming-soon__icon {
+  font-size: 3rem;
+  margin: 0 0 1rem 0;
+}
+
+.coming-soon__message {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #4b5563;
+  margin: 0 0 0.5rem 0;
+}
+
+.coming-soon__detail {
+  font-size: 0.9rem;
+  color: #9ca3af;
+  margin: 0;
+}
+
+.back-section {
+  text-align: center;
+}

--- a/src/Agenda.Frontend/src/app/pages/attendees-search-page/attendees-search-page.component.html
+++ b/src/Agenda.Frontend/src/app/pages/attendees-search-page/attendees-search-page.component.html
@@ -1,0 +1,42 @@
+<section class="attendees-page">
+  <div class="glow glow-left" aria-hidden="true"></div>
+  <div class="glow glow-right" aria-hidden="true"></div>
+
+  <article class="card">
+    <header class="page-header">
+      <p class="kicker">Participants</p>
+      <h1>Recherche de participants</h1>
+      <p class="subtitle">Rechercher un participant par nom ou adresse email.</p>
+    </header>
+
+    <div class="search-section">
+      <form [formGroup]="searchForm" (ngSubmit)="searchAttendees()" class="search-form">
+        <input
+          type="text"
+          formControlName="name"
+          placeholder="Rechercher par nom..."
+          class="search-input"
+          aria-label="Nom du participant"
+        />
+        <input
+          type="email"
+          formControlName="email"
+          placeholder="Rechercher par email..."
+          class="search-input"
+          aria-label="Email du participant"
+        />
+        <button type="submit" class="primary">Rechercher</button>
+      </form>
+    </div>
+
+    <div class="coming-soon">
+      <p class="coming-soon__icon" aria-hidden="true">🔍</p>
+      <p class="coming-soon__message">Fonctionnalité à venir</p>
+      <p class="coming-soon__detail">La recherche de participants sera disponible prochainement.</p>
+    </div>
+
+    <div class="back-section">
+      <button type="button" class="secondary" (click)="goToHome()">← Retour à l'accueil</button>
+    </div>
+  </article>
+</section>

--- a/src/Agenda.Frontend/src/app/pages/attendees-search-page/attendees-search-page.component.ts
+++ b/src/Agenda.Frontend/src/app/pages/attendees-search-page/attendees-search-page.component.ts
@@ -1,0 +1,28 @@
+import { Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-attendees-search-page',
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './attendees-search-page.component.html',
+  styleUrl: './attendees-search-page.component.css'
+})
+export class AttendeesSearchPageComponent {
+  private readonly _router = inject(Router);
+  private readonly _formBuilder = inject(FormBuilder);
+
+  public readonly searchForm = this._formBuilder.nonNullable.group({
+    name: [''],
+    email: ['']
+  });
+
+  public goToHome(): void {
+    this._router.navigate(['/']);
+  }
+
+  public searchAttendees(): void {
+    // Stub: fonctionnalité à venir
+  }
+}

--- a/src/Agenda.Frontend/src/app/pages/home-page/home-page.component.css
+++ b/src/Agenda.Frontend/src/app/pages/home-page/home-page.component.css
@@ -1,0 +1,133 @@
+.home-page {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  padding: 2rem 1rem;
+}
+
+.glow {
+  position: absolute;
+  pointer-events: none;
+  opacity: 0.3;
+}
+
+.glow-left {
+  top: 20%;
+  left: -10%;
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(circle, #3b82f6, transparent);
+  filter: blur(80px);
+}
+
+.glow-right {
+  bottom: 20%;
+  right: -10%;
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(circle, #8b5cf6, transparent);
+  filter: blur(80px);
+}
+
+.home-container {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+.home-header {
+  text-align: center;
+}
+
+.kicker {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #6b7280;
+  margin: 0 0 0.5rem 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.home-header h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem 0;
+  color: #1f2937;
+}
+
+.home-header .subtitle {
+  font-size: 1rem;
+  color: #6b7280;
+  margin: 0;
+}
+
+.nav-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  .nav-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+.nav-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem 1.5rem;
+  border-radius: 1rem;
+  border: none;
+  cursor: pointer;
+  text-align: center;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+.nav-card:hover {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.14);
+}
+
+.nav-card--primary {
+  background: linear-gradient(135deg, #3b82f6, #6366f1);
+  color: white;
+}
+
+.nav-card--accent {
+  background: linear-gradient(135deg, #8b5cf6, #ec4899);
+  color: white;
+}
+
+.nav-card--tertiary {
+  background: linear-gradient(135deg, #0ea5e9, #14b8a6);
+  color: white;
+}
+
+.nav-card__icon {
+  font-size: 2.5rem;
+  line-height: 1;
+}
+
+.nav-card__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.nav-card__description {
+  font-size: 0.9rem;
+  margin: 0;
+  opacity: 0.9;
+  line-height: 1.4;
+}

--- a/src/Agenda.Frontend/src/app/pages/home-page/home-page.component.html
+++ b/src/Agenda.Frontend/src/app/pages/home-page/home-page.component.html
@@ -1,0 +1,32 @@
+<section class="home-page">
+  <div class="glow glow-left" aria-hidden="true"></div>
+  <div class="glow glow-right" aria-hidden="true"></div>
+
+  <div class="home-container">
+    <header class="home-header">
+      <p class="kicker">Agenda</p>
+      <h1>Bienvenue dans votre agenda</h1>
+      <p class="subtitle">Gérez vos rendez-vous en toute simplicité.</p>
+    </header>
+
+    <div class="nav-cards">
+      <button type="button" class="nav-card nav-card--primary" (click)="goToAppointments()">
+        <span class="nav-card__icon" aria-hidden="true">📅</span>
+        <h2 class="nav-card__title">Agenda</h2>
+        <p class="nav-card__description">Consulter vos rendez-vous des 2 prochaines semaines</p>
+      </button>
+
+      <button type="button" class="nav-card nav-card--accent" (click)="goToNewAppointment()">
+        <span class="nav-card__icon" aria-hidden="true">➕</span>
+        <h2 class="nav-card__title">Nouveau rendez-vous</h2>
+        <p class="nav-card__description">Planifier un nouveau rendez-vous</p>
+      </button>
+
+      <button type="button" class="nav-card nav-card--tertiary" (click)="goToAttendees()">
+        <span class="nav-card__icon" aria-hidden="true">🔍</span>
+        <h2 class="nav-card__title">Participants</h2>
+        <p class="nav-card__description">Rechercher un participant par nom ou adresse email</p>
+      </button>
+    </div>
+  </div>
+</section>

--- a/src/Agenda.Frontend/src/app/pages/home-page/home-page.component.spec.ts
+++ b/src/Agenda.Frontend/src/app/pages/home-page/home-page.component.spec.ts
@@ -1,0 +1,115 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HomePageComponent } from './home-page.component';
+import { Router } from '@angular/router';
+import { vi } from 'vitest';
+
+describe('HomePageComponent', () => {
+  let component: HomePageComponent;
+  let fixture: ComponentFixture<HomePageComponent>;
+  let routerSpy: { navigate: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    routerSpy = {
+      navigate: vi.fn()
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [HomePageComponent],
+      providers: [
+        {
+          provide: Router,
+          useValue: routerSpy
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HomePageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should navigate to /appointments when goToAppointments is called', () => {
+    // Act
+    component.goToAppointments();
+
+    // Assert
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/appointments']);
+  });
+
+  it('should navigate to /appointments/new when goToNewAppointment is called', () => {
+    // Act
+    component.goToNewAppointment();
+
+    // Assert
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/appointments/new']);
+  });
+
+  it('should navigate to /attendees when goToAttendees is called', () => {
+    // Act
+    component.goToAttendees();
+
+    // Assert
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/attendees']);
+  });
+
+  it('should render the Agenda navigation card', () => {
+    // Assert
+    const cardTitles = fixture.nativeElement.querySelectorAll('.nav-card__title') as NodeList;
+    const titles = Array.from(cardTitles).map((node) => (node as HTMLElement).textContent?.trim());
+    expect(titles).toContain('Agenda');
+  });
+
+  it('should render the Nouveau rendez-vous navigation card', () => {
+    // Assert
+    const cardTitles = fixture.nativeElement.querySelectorAll('.nav-card__title') as NodeList;
+    const titles = Array.from(cardTitles).map((node) => (node as HTMLElement).textContent?.trim());
+    expect(titles).toContain('Nouveau rendez-vous');
+  });
+
+  it('should render the Participants navigation card', () => {
+    // Assert
+    const cardTitles = fixture.nativeElement.querySelectorAll('.nav-card__title') as NodeList;
+    const titles = Array.from(cardTitles).map((node) => (node as HTMLElement).textContent?.trim());
+    expect(titles).toContain('Participants');
+  });
+
+  it('should trigger goToAppointments when the Agenda card is clicked', () => {
+    // Arrange
+    const navigateSpy = vi.spyOn(component, 'goToAppointments');
+
+    // Act
+    const agendaCard = fixture.nativeElement.querySelector('.nav-card--primary') as HTMLButtonElement;
+    agendaCard.click();
+
+    // Assert
+    expect(navigateSpy).toHaveBeenCalled();
+  });
+
+  it('should trigger goToNewAppointment when the accent card is clicked', () => {
+    // Arrange
+    const navigateSpy = vi.spyOn(component, 'goToNewAppointment');
+
+    // Act
+    const newCard = fixture.nativeElement.querySelector('.nav-card--accent') as HTMLButtonElement;
+    newCard.click();
+
+    // Assert
+    expect(navigateSpy).toHaveBeenCalled();
+  });
+
+  it('should trigger goToAttendees when the tertiary card is clicked', () => {
+    // Arrange
+    const navigateSpy = vi.spyOn(component, 'goToAttendees');
+
+    // Act
+    const attendeesCard = fixture.nativeElement.querySelector('.nav-card--tertiary') as HTMLButtonElement;
+    attendeesCard.click();
+
+    // Assert
+    expect(navigateSpy).toHaveBeenCalled();
+  });
+});

--- a/src/Agenda.Frontend/src/app/pages/home-page/home-page.component.ts
+++ b/src/Agenda.Frontend/src/app/pages/home-page/home-page.component.ts
@@ -1,0 +1,24 @@
+import { Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-home-page',
+  imports: [],
+  templateUrl: './home-page.component.html',
+  styleUrl: './home-page.component.css'
+})
+export class HomePageComponent {
+  private readonly _router = inject(Router);
+
+  public goToAppointments(): void {
+    this._router.navigate(['/appointments']);
+  }
+
+  public goToNewAppointment(): void {
+    this._router.navigate(['/appointments/new']);
+  }
+
+  public goToAttendees(): void {
+    this._router.navigate(['/attendees']);
+  }
+}

--- a/src/Agenda.Frontend/src/app/pages/schedule-appointment-page/schedule-appointment-page.component.css
+++ b/src/Agenda.Frontend/src/app/pages/schedule-appointment-page/schedule-appointment-page.component.css
@@ -213,6 +213,16 @@ button:disabled {
   color: color-mix(in srgb, var(--danger) 84%, black);
 }
 
+.form-actions {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.cancel-button,
+.form-actions .primary {
+  width: 100%;
+}
+
 /* ── ≥ 480px: restore floating card ─────────────────────────────────────── */
 @media (min-width: 480px) {
   .schedule-page {
@@ -255,8 +265,13 @@ button:disabled {
 
   .attendees,
   .feedback,
-  .primary {
+  .form-actions {
     grid-column: 1 / -1;
+  }
+
+  .form-actions {
+    grid-template-columns: minmax(0, 180px) minmax(0, 1fr);
+    align-items: stretch;
   }
 
   /* name | email | phone | [remove] in a single row */

--- a/src/Agenda.Frontend/src/app/pages/schedule-appointment-page/schedule-appointment-page.component.html
+++ b/src/Agenda.Frontend/src/app/pages/schedule-appointment-page/schedule-appointment-page.component.html
@@ -73,13 +73,17 @@
         <p class="feedback success">Rendez-vous créé avec succès (id: {{ createdAppointmentId }}).</p>
       }
 
-      <button class="primary" type="submit" [disabled]="isSubmitting">
-        @if (isSubmitting) {
-          <span>Planification...</span>
-        } @else {
-          <span>Planifier le rendez-vous</span>
-        }
-      </button>
+      <div class="form-actions">
+        <button class="ghost cancel-button" type="button" (click)="cancel()">Annuler</button>
+
+        <button class="primary" type="submit" [disabled]="isSubmitting">
+          @if (isSubmitting) {
+            <span>Planification...</span>
+          } @else {
+            <span>Planifier le rendez-vous</span>
+          }
+        </button>
+      </div>
     </form>
   </article>
 </section>

--- a/src/Agenda.Frontend/src/app/pages/schedule-appointment-page/schedule-appointment-page.component.spec.ts
+++ b/src/Agenda.Frontend/src/app/pages/schedule-appointment-page/schedule-appointment-page.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { vi } from 'vitest';
 import { ApiService } from '../../../services/api-service';
@@ -8,6 +9,7 @@ describe('ScheduleAppointmentPageComponent', () => {
   let component: ScheduleAppointmentPageComponent;
   let fixture: ComponentFixture<ScheduleAppointmentPageComponent>;
   let apiServiceSpy: { scheduleAppointment: ReturnType<typeof vi.fn> };
+  let routerSpy: { navigate: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
     apiServiceSpy = {
@@ -23,6 +25,9 @@ describe('ScheduleAppointmentPageComponent', () => {
         links: []
       }))
     };
+    routerSpy = {
+      navigate: vi.fn()
+    };
 
     await TestBed.configureTestingModule({
       imports: [ScheduleAppointmentPageComponent],
@@ -30,6 +35,10 @@ describe('ScheduleAppointmentPageComponent', () => {
         {
           provide: ApiService,
           useValue: apiServiceSpy
+        },
+        {
+          provide: Router,
+          useValue: routerSpy
         }
       ]
     }).compileComponents();
@@ -37,6 +46,10 @@ describe('ScheduleAppointmentPageComponent', () => {
     fixture = TestBed.createComponent(ScheduleAppointmentPageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('should create', () => {
@@ -76,5 +89,42 @@ describe('ScheduleAppointmentPageComponent', () => {
     }));
 
     expect(component.createdAppointmentId).toBe('appt_001');
+  });
+
+  it('does not show a confirmation when cancelling a pristine form', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm');
+
+    const cancelButton = fixture.nativeElement.querySelector('.cancel-button') as HTMLButtonElement;
+    cancelButton.click();
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/']);
+  });
+
+  it('keeps the user on the page when cancelling a dirty form and the confirmation is rejected', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    component.appointmentForm.controls.subject.setValue('Comite produit');
+    component.appointmentForm.controls.subject.markAsDirty();
+    fixture.detectChanges();
+
+    const cancelButton = fixture.nativeElement.querySelector('.cancel-button') as HTMLButtonElement;
+    cancelButton.click();
+
+    expect(confirmSpy).toHaveBeenCalledOnce();
+    expect(routerSpy.navigate).not.toHaveBeenCalled();
+    expect(component.appointmentForm.controls.subject.value).toBe('Comite produit');
+  });
+
+  it('shows a confirmation when cancelling a dirty form and navigates home after approval', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    component.appointmentForm.controls.subject.setValue('Comite produit');
+    component.appointmentForm.controls.subject.markAsDirty();
+    fixture.detectChanges();
+
+    const cancelButton = fixture.nativeElement.querySelector('.cancel-button') as HTMLButtonElement;
+    cancelButton.click();
+
+    expect(confirmSpy).toHaveBeenCalledOnce();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/']);
   });
 });

--- a/src/Agenda.Frontend/src/app/pages/schedule-appointment-page/schedule-appointment-page.component.ts
+++ b/src/Agenda.Frontend/src/app/pages/schedule-appointment-page/schedule-appointment-page.component.ts
@@ -17,6 +17,7 @@ export class ScheduleAppointmentPageComponent {
   private readonly _formBuilder = inject(FormBuilder);
   private readonly _apiService = inject(ApiService);
   private readonly _router = inject(Router);
+  private readonly _cancelConfirmationMessage = 'Les modifications non enregistrees seront perdues. Voulez-vous vraiment quitter cette page ?';
 
   public isSubmitting = false;
   public createdAppointmentId: string | null = null;
@@ -41,6 +42,18 @@ export class ScheduleAppointmentPageComponent {
   public removeAttendee(index: number): void {
     if (this.attendees.length > 1) {
       this.attendees.removeAt(index);
+    }
+  }
+
+  public cancel(): void {
+    let shouldNavigate = true;
+
+    if (this.appointmentForm.dirty) {
+      shouldNavigate = window.confirm(this._cancelConfirmationMessage);
+    }
+
+    if (shouldNavigate) {
+      this._router.navigate(['/']);
     }
   }
 

--- a/src/Agenda.Frontend/src/models/page-of.ts
+++ b/src/Agenda.Frontend/src/models/page-of.ts
@@ -11,6 +11,12 @@ export interface PageOf<T> {
   /** Number of items in the current page */
   count: number;
 
+  /** Requested page size (when provided by backend) */
+  pageSize?: number;
+
+  /** Total number of matching items across all pages (when provided by backend) */
+  totalCount?: number;
+
   /** Items in the current page */
   items: T[];
 

--- a/src/Agenda.Frontend/src/services/api-service.spec.ts
+++ b/src/Agenda.Frontend/src/services/api-service.spec.ts
@@ -162,6 +162,48 @@ describe('ApiService with HTTP', () => {
     });
   });
 
+  it('should normalize PascalCase paginated payload to frontend camelCase contract', () => {
+    apiService.getAppointments({ page: 1, pageSize: 10 }).subscribe((response) => {
+      expect(response.page).toBe(1);
+      expect(response.total).toBe(3);
+      expect(response.count).toBe(1);
+      expect(response.items.length).toBe(1);
+      expect(response.items[0].resource.id).toBe('appt_pascal_001');
+      expect(response.items[0].resource.subject).toBe('Pascal payload');
+      expect(response.links.last?.href).toContain('page=3');
+      expect(response.links.next?.href).toContain('page=2');
+    });
+
+    const req = httpMock.expectOne((request) =>
+      request.url === '/api/appointments'
+      && request.params.get('page') === '1'
+      && request.params.get('pageSize') === '10'
+    );
+
+    req.flush({
+      Page: 1,
+      Total: 3,
+      Count: 1,
+      Items: [
+        {
+          Resource: {
+            Id: 'appt_pascal_001',
+            Subject: 'Pascal payload',
+            Location: 'Room E',
+            StartDate: '2026-05-30T09:00:00Z',
+            EndDate: '2026-05-30T10:00:00Z',
+            Attendees: []
+          },
+          Links: []
+        }
+      ],
+      Links: {
+        Next: { Href: '/appointments?page=2', Relations: ['next'] },
+        Last: { Href: '/appointments?page=3', Relations: ['last'] }
+      }
+    });
+  });
+
   it('should filter appointments by subject', () => {
     const mockResponse: PageOf<Browsable<Appointment>> = {
       page: 1,

--- a/src/Agenda.Frontend/src/services/api-service.spec.ts
+++ b/src/Agenda.Frontend/src/services/api-service.spec.ts
@@ -312,6 +312,33 @@ describe('ApiService with HTTP', () => {
     req.flush({ message: 'Validation error' }, { status: 400, statusText: 'Bad Request' });
   });
 
+  it('should return total appointment count from HEAD response total header', () => {
+    // countAppointments() will be implemented by Dallas — tests prepared ahead of time
+    return new Promise<void>((resolve) => {
+      (apiService as any).countAppointments().subscribe((count: number) => {
+        expect(count).toBe(5);
+        resolve();
+      });
+
+      const req = httpMock.expectOne('/api/appointments');
+      expect(req.request.method).toBe('HEAD');
+      req.flush(null, { headers: { total: '5' } });
+    });
+  });
+
+  it('should return 0 when total header is absent from HEAD response', () => {
+    return new Promise<void>((resolve) => {
+      (apiService as any).countAppointments().subscribe((count: number) => {
+        expect(count).toBe(0);
+        resolve();
+      });
+
+      const req = httpMock.expectOne('/api/appointments');
+      expect(req.request.method).toBe('HEAD');
+      req.flush(null, { headers: {} });
+    });
+  });
+
     afterEach(() => {
       httpMock.verify();
     });

--- a/src/Agenda.Frontend/src/services/api-service.spec.ts
+++ b/src/Agenda.Frontend/src/services/api-service.spec.ts
@@ -98,6 +98,70 @@ describe('ApiService with HTTP', () => {
     req.flush(mockResponse);
   });
 
+  it('should merge pagination metadata from HATEOAS headers when body links are missing', () => {
+    const mockResponse: PageOf<Browsable<Appointment>> = {
+      page: 2,
+      total: 1,
+      count: 0,
+      items: [],
+      links: {}
+    };
+
+    apiService.getAppointments({ page: 2, pageSize: 10 }).subscribe((response) => {
+      expect(response.page).toBe(2);
+      expect(response.total).toBe(4);
+      expect(response.count).toBe(10);
+      expect(response.links.previous?.href).toContain('page=1');
+      expect(response.links.next?.href).toContain('page=3');
+      expect(response.links.last?.href).toContain('page=4');
+    });
+
+    const req = httpMock.expectOne((request) =>
+      request.url === '/api/appointments'
+      && request.params.get('page') === '2'
+      && request.params.get('pageSize') === '10'
+    );
+
+    req.flush(mockResponse, {
+      headers: {
+        total: '40',
+        count: '10',
+        Link: [
+          '</api/appointments?page=1&pageSize=10>; rel="first"',
+          '</api/appointments?page=1&pageSize=10>; rel="previous"',
+          '</api/appointments?page=3&pageSize=10>; rel="next"',
+          '</api/appointments?page=4&pageSize=10>; rel="last"'
+        ]
+      }
+    });
+  });
+
+  it('should support rel="prev" alias from link headers', () => {
+    const mockResponse: PageOf<Browsable<Appointment>> = {
+      page: 2,
+      total: 2,
+      count: 1,
+      items: [],
+      links: {}
+    };
+
+    apiService.getAppointments({ page: 2, pageSize: 10 }).subscribe((response) => {
+      expect(response.links.previous?.href).toContain('page=1');
+    });
+
+    const req = httpMock.expectOne((request) =>
+      request.url === '/api/appointments'
+      && request.params.get('page') === '2'
+      && request.params.get('pageSize') === '10'
+    );
+
+    req.flush(mockResponse, {
+      headers: {
+        Link: '</api/appointments?page=1&pageSize=10>; rel="prev"'
+      }
+    });
+  });
+
   it('should filter appointments by subject', () => {
     const mockResponse: PageOf<Browsable<Appointment>> = {
       page: 1,

--- a/src/Agenda.Frontend/src/services/api-service.ts
+++ b/src/Agenda.Frontend/src/services/api-service.ts
@@ -63,6 +63,41 @@ export class ApiService {
     return this.http.post<Browsable<Appointment>>('/api/appointments', payload);
   }
 
+  /** Counts appointments matching the given parameters via HEAD request. Returns an Observable of the total from the `total` response header. */
+  public countAppointments(params?: SearchAppointmentsParams): Observable<number> {
+    let httpParams: HttpParams = new HttpParams();
+
+    if (params) {
+      if (params.page !== undefined) {
+        httpParams = httpParams.set('page', params.page.toString());
+      }
+      if (params.pageSize !== undefined) {
+        httpParams = httpParams.set('pageSize', params.pageSize.toString());
+      }
+      if (params.subject !== undefined && params.subject.trim()) {
+        httpParams = httpParams.set('subject', params.subject);
+      }
+      if (params.location !== undefined && params.location.trim()) {
+        httpParams = httpParams.set('location', params.location);
+      }
+      if (params.from !== undefined) {
+        httpParams = httpParams.set('from', params.from);
+      }
+      if (params.to !== undefined) {
+        httpParams = httpParams.set('to', params.to);
+      }
+    }
+
+    return this.http
+      .head<void>('/api/appointments', {
+        params: httpParams,
+        observe: 'response'
+      })
+      .pipe(
+        map((response) => this.parsePositiveInteger(response.headers.get('total')) ?? 0)
+      );
+  }
+
   private toPaginatedAppointmentsResponse(
     response: HttpResponse<PageOf<Browsable<Appointment>>>,
     requestedPageSize?: number

--- a/src/Agenda.Frontend/src/services/api-service.ts
+++ b/src/Agenda.Frontend/src/services/api-service.ts
@@ -67,13 +67,7 @@ export class ApiService {
     response: HttpResponse<PageOf<Browsable<Appointment>>>,
     requestedPageSize?: number
   ): PageOf<Browsable<Appointment>> {
-    const body = response.body ?? {
-      page: 1,
-      total: 1,
-      count: 0,
-      items: [],
-      links: {}
-    };
+    const body = this.normalizePaginatedBody(response.body);
 
     const linksFromHeaders = this.extractPageLinksFromHeaders(response.headers);
     const mergedLinks: PageLinks = {
@@ -101,6 +95,155 @@ export class ApiService {
       count: countFromHeaders ?? body.count ?? body.items.length,
       links: mergedLinks
     };
+  }
+
+  private normalizePaginatedBody(responseBody: PageOf<Browsable<Appointment>> | null): PageOf<Browsable<Appointment>> {
+    const rawBody = this.toRecord(responseBody);
+    if (!rawBody) {
+      return {
+        page: 1,
+        total: 1,
+        count: 0,
+        items: [],
+        links: {}
+      };
+    }
+
+    const rawPageSize = this.readNumber(rawBody, 'pageSize', 'PageSize');
+    const rawTotalCount = this.readNumber(rawBody, 'totalCount', 'TotalCount');
+
+    return {
+      page: this.readNumber(rawBody, 'page', 'Page') ?? 1,
+      total: this.readNumber(rawBody, 'total', 'Total') ?? 1,
+      count: this.readNumber(rawBody, 'count', 'Count') ?? 0,
+      pageSize: rawPageSize ?? undefined,
+      totalCount: rawTotalCount ?? undefined,
+      items: this.normalizeBrowsables(rawBody['items'] ?? rawBody['Items']),
+      links: this.normalizePageLinks(rawBody['links'] ?? rawBody['Links'])
+    };
+  }
+
+  private normalizeBrowsables(rawItems: unknown): Browsable<Appointment>[] {
+    if (!Array.isArray(rawItems)) {
+      return [];
+    }
+
+    return rawItems
+      .map((rawItem) => this.normalizeBrowsable(rawItem))
+      .filter((item): item is Browsable<Appointment> => item !== null);
+  }
+
+  private normalizeBrowsable(rawItem: unknown): Browsable<Appointment> | null {
+    const item = this.toRecord(rawItem);
+    if (!item) {
+      return null;
+    }
+
+    const resource = this.normalizeAppointment(item['resource'] ?? item['Resource']);
+    if (!resource) {
+      return null;
+    }
+
+    const rawLinks = item['links'] ?? item['Links'];
+
+    return {
+      resource,
+      links: Array.isArray(rawLinks)
+        ? rawLinks as Array<{ href: string; method?: string; relations?: string[] }>
+        : []
+    };
+  }
+
+  private normalizeAppointment(rawResource: unknown): Appointment | null {
+    const resource = this.toRecord(rawResource);
+    if (!resource) {
+      return null;
+    }
+
+    const id = this.readString(resource, 'id', 'Id');
+    const subject = this.readString(resource, 'subject', 'Subject');
+    const location = this.readString(resource, 'location', 'Location');
+    const startDate = this.readString(resource, 'startDate', 'StartDate');
+    const endDate = this.readString(resource, 'endDate', 'EndDate');
+
+    if (!id || !subject || !location || !startDate || !endDate) {
+      return null;
+    }
+
+    const rawAttendees = resource['attendees'] ?? resource['Attendees'];
+
+    return {
+      id,
+      subject,
+      location,
+      startDate,
+      endDate,
+      attendees: Array.isArray(rawAttendees)
+        ? rawAttendees as Appointment['attendees']
+        : []
+    };
+  }
+
+  private normalizePageLinks(rawLinks: unknown): PageLinks {
+    const links = this.toRecord(rawLinks);
+    if (!links) {
+      return {};
+    }
+
+    return {
+      first: this.normalizePageLink(links['first'] ?? links['First']),
+      last: this.normalizePageLink(links['last'] ?? links['Last']),
+      previous: this.normalizePageLink(links['previous'] ?? links['Previous']),
+      next: this.normalizePageLink(links['next'] ?? links['Next'])
+    };
+  }
+
+  private normalizePageLink(rawLink: unknown): PageLink | undefined {
+    const link = this.toRecord(rawLink);
+    if (!link) {
+      return undefined;
+    }
+
+    const href = this.readString(link, 'href', 'Href');
+    if (!href) {
+      return undefined;
+    }
+
+    const rawRelations = link['relations'] ?? link['Relations'];
+    const relations = Array.isArray(rawRelations)
+      ? rawRelations as string[]
+      : [];
+
+    return {
+      href,
+      relations
+    };
+  }
+
+  private toRecord(value: unknown): Record<string, unknown> | null {
+    if (typeof value !== 'object' || value === null) {
+      return null;
+    }
+
+    return value as Record<string, unknown>;
+  }
+
+  private readNumber(source: Record<string, unknown>, camelCaseKey: string, pascalCaseKey: string): number | null {
+    const rawValue = source[camelCaseKey] ?? source[pascalCaseKey];
+    if (typeof rawValue !== 'number' || !Number.isFinite(rawValue)) {
+      return null;
+    }
+
+    return rawValue;
+  }
+
+  private readString(source: Record<string, unknown>, camelCaseKey: string, pascalCaseKey: string): string | null {
+    const rawValue = source[camelCaseKey] ?? source[pascalCaseKey];
+    if (typeof rawValue !== 'string') {
+      return null;
+    }
+
+    return rawValue;
   }
 
   private extractPageLinksFromHeaders(headers: HttpHeaders): PageLinks {

--- a/src/Agenda.Frontend/src/services/api-service.ts
+++ b/src/Agenda.Frontend/src/services/api-service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams, HttpResponse } from '@angular/common/http';
 import { Appointment } from '../models/appointment';
-import { Observable } from 'rxjs';
+import { map, Observable } from 'rxjs';
 import { NewAppointmentPayload } from '../models/new-appointment-payload';
 import { Browsable } from '../models/browsable';
-import { PageOf } from '../models/page-of';
+import { PageLink, PageLinks, PageOf } from '../models/page-of';
 import { SearchAppointmentsParams } from '../models/search-appointments-params';
 
 @Injectable({
@@ -48,11 +48,158 @@ export class ApiService {
       }
     }
 
-    return this.http.get<PageOf<Browsable<Appointment>>>('/api/appointments', { params: httpParams });
+    return this.http
+      .get<PageOf<Browsable<Appointment>>>('/api/appointments', {
+        params: httpParams,
+        observe: 'response'
+      })
+      .pipe(
+        map((response) => this.toPaginatedAppointmentsResponse(response, params?.pageSize))
+      );
   }
 
   /** Creates a new appointment. */
   public scheduleAppointment(payload: NewAppointmentPayload): Observable<Browsable<Appointment>> {
     return this.http.post<Browsable<Appointment>>('/api/appointments', payload);
+  }
+
+  private toPaginatedAppointmentsResponse(
+    response: HttpResponse<PageOf<Browsable<Appointment>>>,
+    requestedPageSize?: number
+  ): PageOf<Browsable<Appointment>> {
+    const body = response.body ?? {
+      page: 1,
+      total: 1,
+      count: 0,
+      items: [],
+      links: {}
+    };
+
+    const linksFromHeaders = this.extractPageLinksFromHeaders(response.headers);
+    const mergedLinks: PageLinks = {
+      ...(body.links ?? {}),
+      ...linksFromHeaders
+    };
+
+    const totalItemsFromHeaders = this.parsePositiveInteger(response.headers.get('total'));
+    const countFromHeaders = this.parsePositiveInteger(response.headers.get('count'));
+    const currentPage = this.normalizePageNumber(body.page);
+    const pageSize = this.resolvePageSize(body, requestedPageSize, countFromHeaders);
+    const totalPagesFromLinks = this.extractLastPageFromLinks(mergedLinks);
+    const totalPagesFromHeaders = totalItemsFromHeaders !== null
+      ? this.normalizePageNumber(Math.ceil(totalItemsFromHeaders / pageSize))
+      : null;
+    const totalPages = totalPagesFromLinks
+      ?? totalPagesFromHeaders
+      ?? this.normalizePageNumber(body.total)
+      ?? 1;
+
+    return {
+      ...body,
+      page: Math.min(currentPage, totalPages),
+      total: totalPages,
+      count: countFromHeaders ?? body.count ?? body.items.length,
+      links: mergedLinks
+    };
+  }
+
+  private extractPageLinksFromHeaders(headers: HttpHeaders): PageLinks {
+    const parsedLinks: PageLinks = {};
+    const values = headers.getAll('Link') ?? [];
+    const linkPattern = /<([^>]+)>\s*;\s*rel="([^"]+)"/gi;
+
+    values.forEach((headerValue) => {
+      const matches = headerValue.matchAll(linkPattern);
+      Array.from(matches).forEach((match) => {
+        const href = match[1]?.trim();
+        const relationValue = match[2]?.trim();
+
+        if (!href || !relationValue) {
+          return;
+        }
+
+        relationValue
+          .split(/\s+/)
+          .map((relation) => relation.trim().toLowerCase())
+          .filter(Boolean)
+          .forEach((relation) => {
+            const normalizedRelation = relation === 'prev' ? 'previous' : relation;
+            const link: PageLink = { href, relations: [normalizedRelation] };
+
+            switch (normalizedRelation) {
+              case 'first':
+                parsedLinks.first = parsedLinks.first ?? link;
+                break;
+              case 'last':
+                parsedLinks.last = parsedLinks.last ?? link;
+                break;
+              case 'previous':
+                parsedLinks.previous = parsedLinks.previous ?? link;
+                break;
+              case 'next':
+                parsedLinks.next = parsedLinks.next ?? link;
+                break;
+              default:
+                break;
+            }
+          });
+      });
+    });
+
+    return parsedLinks;
+  }
+
+  private extractLastPageFromLinks(links: PageLinks): number | null {
+    return this.extractPageNumber(links.last?.href);
+  }
+
+  private extractPageNumber(href?: string): number | null {
+    if (!href) {
+      return null;
+    }
+
+    try {
+      const url = new URL(href, window.location.origin);
+      const page = Number.parseInt(url.searchParams.get('page') ?? '', 10);
+      return Number.isNaN(page) ? null : this.normalizePageNumber(page);
+    } catch {
+      return null;
+    }
+  }
+
+  private parsePositiveInteger(value: string | null): number | null {
+    if (!value) {
+      return null;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isNaN(parsed) || parsed < 0) {
+      return null;
+    }
+
+    return parsed;
+  }
+
+  private resolvePageSize(
+    body: PageOf<Browsable<Appointment>>,
+    requestedPageSize?: number,
+    countFromHeaders?: number | null
+  ): number {
+    const candidates = [body.pageSize, requestedPageSize, body.count, countFromHeaders, body.items.length, 1];
+    const firstPositiveCandidate = candidates.find((candidate) =>
+      typeof candidate === 'number'
+      && Number.isFinite(candidate)
+      && candidate > 0
+    );
+
+    return firstPositiveCandidate ?? 1;
+  }
+
+  private normalizePageNumber(page: number | null | undefined): number {
+    if (typeof page !== 'number' || !Number.isFinite(page) || page <= 0) {
+      return 1;
+    }
+
+    return Math.floor(page);
   }
 }

--- a/tests/Agenda.API.UnitTests/Features/Appointments/v1/Search/SearchAppointmentsEndpointShould.cs
+++ b/tests/Agenda.API.UnitTests/Features/Appointments/v1/Search/SearchAppointmentsEndpointShould.cs
@@ -402,6 +402,30 @@ public sealed class SearchAppointmentsEndpointShould : IClassFixture<PostgresSql
                           });
             }
 
+            // Search with default page and pageSize values (no explicit values provided)
+            {
+                List<Appointment> data = s_appointementFaker.Generate(15);
+                SearchAppointmentRequest request = new(); // Uses default values: Page = 1, PageSize = 10
+
+                cases.Add(data,
+                          request,
+                          new XunitSerializableExpression<PageOf<Browsable<AppointmentInfo>>>
+                          {
+                              Value = pageOfAppointments => pageOfAppointments.Total == 2
+                                                            && pageOfAppointments.TotalCount == 15
+                                                            && pageOfAppointments.PageSize == 10
+                                                            && pageOfAppointments.Count == 10
+                                                            && pageOfAppointments.Items != null
+                                                            && pageOfAppointments.Items.Exactly(10)
+                                                            && pageOfAppointments.Page == 1
+                                                            && pageOfAppointments.Links != null
+                                                            && pageOfAppointments.Links.First != null
+                                                            && pageOfAppointments.Links.Previous == null
+                                                            && pageOfAppointments.Links.Next != null
+                                                            && pageOfAppointments.Links.Last != null
+                          });
+            }
+
             return cases;
         }
     }


### PR DESCRIPTION
## Summary
- Add a new homepage with navigation cards for the agenda, appointment creation, and participants search
- Add a live appointment result counter powered by `HEAD /appointments` on the search page
- Add a cancellable appointment creation flow with confirmation when the form is dirty
- Add a participants search page stub and route wiring
- Update the changelog to document the frontend changes

## Validation
- `npm run test -- --watch false`
- `npm run build`

## Notes
- The branch also includes supporting frontend contract updates for pagination and HATEOAS handling.