### PR TITLE
feat(api): migrate API docs UI from Swagger to Scalar

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -34,6 +34,7 @@ Initial setup complete.
 - Preserve active filters (including `location`) in pagination links to keep navigation coherent.
 - AppHost startup can fail before compilation when `global.json` pins an unavailable SDK; aligning to an available patch/feature band is a minimal unblocker when `rollForward` is already configured.
 - Reusing one response interceptor for both `Browsable<T>` and `PageOf<T>` keeps `GET`/`HEAD` metadata behavior consistent and prevents header drift between slices.
+- Replacing Swagger UI with Scalar in FastEndpoints can stay minimal by keeping `SwaggerDocument(...)` for OpenAPI generation, switching runtime exposure to `UseOpenApi(...)` + `MapScalarApiReference(...)`, and updating launch URLs from `/swagger` to `/scalar`.
 ## Learning — 2026-05-27T19:56:18Z: Aspire health check endpoint binding
 `WithHttpHealthCheck("/health")` without `endpointName` defaults to the first endpoint declared in `launchSettings.json` (HTTPS first in this repo). On a CI Linux runner without ASP.NET Core dev cert, that probe fails and — combined with `WaitForResourceHealthyAsync` — blocks integration test bootstrap. Always pass `endpointName: "http"` for Aspire health checks in integration test scenarios. Context: PR #546 diagnostic with Hicks.
 

--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -166,3 +166,6 @@ import { vi } from 'vitest';
 - Report executed commands and outcomes with enough detail for quick session-log consolidation.
 ## Learning — 2026-05-27T19:56:18Z: Aspire health check endpoint binding
 `WithHttpHealthCheck` without `endpointName` defaults to the first endpoint in `launchSettings.json` (HTTPS first) → fails on CI Linux without dev cert. Always pass `endpointName: "http"` for Aspire health checks in integration test scenarios. The failure was previously silent until `WaitForResourceHealthyAsync` was introduced in PR #546, which turned it into a blocking bootstrap error. Cross-checked with Bishop.
+
+## Learning — 2026-05-29T00:00:00Z: Swagger-to-Scalar test baseline should validate UI and JSON endpoints
+For the Swagger UI to Scalar migration, endpoint coverage is release-safe when integration tests assert all three behaviors together: Scalar UI is reachable (`/scalar` or `/scalar/v1`), Swagger UI is removed (`/swagger` returns 404), and the OpenAPI document remains available (`/openapi/v1.json` returns JSON with an `openapi` field). Validating only UI presence can miss regressions where Scalar loads but OpenAPI generation or routing is broken.

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -30,3 +30,8 @@ Agent Lambert initialized and ready for work.
 
 ### 2026-05-24: Issue #545 docs assignment context
 - For coordinated issue batches, keep CHANGELOG wording concise and aligned to validated behavior from implementation/tests.
+
+### 2026-05-29: Issue #571 API docs UI migration note
+- Documented the API documentation UI migration from Swagger UI to Scalar in `CHANGELOG.md` under Unreleased > API.
+- Kept the changelog entry explicit that the OpenAPI JSON document remains available for tooling compatibility.
+- Used a minimal single-bullet update with an issue link for traceability.

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -38,3 +38,9 @@ Initial setup complete.
 - Recorded Dallas' frontend change for schedule-page cancel navigation in both orchestration and session logs.
 - Merged the remaining Dallas inbox entry covering homepage routing, HEAD count retrieval, and attendees stub registration into `decisions.md`.
 - Cross-agent history should capture validation evidence when the agent reports both targeted tests and build status, even if the Squad task itself is documentation-only.
+
+### 2026-05-29: Logged Swagger UI to Scalar documentation migration batch
+
+- Recorded one orchestration entry for Bishop (backend migration) and one for Hicks (integration test coverage/validation).
+- Created a concise session log linking migration scope and targeted validation outcomes.
+- Merged all pending decision inbox entries into `decisions.md` and cleared merged inbox files.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,6 +2,23 @@
 
 ## Active Decisions
 
+### 2026-05-29T07:08:11Z: User directive - Present results as dashboard/table
+**By:** Cyrille NDOUMBE (via Copilot)
+**What:** Going forward, present results in a dashboard/table format.
+**Why:** User request - captured for team memory.
+
+### 2026-05-29T07:26:14Z: Backend documentation UI surface should use Scalar
+**By:** Bishop
+**What:** Replace runtime Swagger UI exposure with Scalar while keeping FastEndpoints/OpenAPI document generation and JSON exposure.
+**Why:** Complete the Swagger UI to Scalar migration with minimal backend churn and preserve tooling compatibility.
+**Impact:** Local documentation entrypoint is Scalar, Swagger UI route is removed, and OpenAPI JSON remains available.
+
+### 2026-05-29T07:26:14Z: Documentation endpoint regression coverage must validate UI and OpenAPI contract
+**By:** Hicks
+**What:** Integration tests for documentation routing should validate three behaviors together: Scalar UI is reachable, Swagger UI is not exposed, and v1 OpenAPI JSON is available and valid.
+**Why:** UI-only checks can miss regressions where documentation rendering depends on missing or invalid OpenAPI output.
+**Impact:** Stronger release confidence for API consumers and tooling that rely on OpenAPI.
+
 ### 2026-05-26T21:08:36Z: User directive — English-only user-facing docs
 **By:** Cyrille NDOUMBE (via Copilot)
 **What:** Keep every user-facing documentation in English for this public repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added publication of `AppointmentScheduled` event when a new appointment is scheduled : 
 - Added publication of `AppointmentCreated` event when a new appointment is created, containing appointment ID, start/end dates (ISO 8601), location, attendees list, and creator ID (#329)
 - Added healthchecks for PostgreSQL and RabbitMQ
+- Migrated API documentation UI from Swagger UI to Scalar while keeping the OpenAPI JSON document available ([#571](https://github.com/candoumbe/agenda/issues/571))
 - Updated appointments paginated headers contract for UI navigation: `total` now represents the total number of matching elements, `count` represents the number of elements in the current page, and redundant `totalCount` was removed
 - Added multi-criteria filtering for appointments listing (`subject`, `location`, and `from`/`to` time range)
 - Fixed appointments search query binding for ISO `OffsetDateTime` range filters so first-load requests return `200` instead of `400`

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -81,6 +81,7 @@
     <PackageVersion Include="Paramore.Brighter.PostgreSql.EntityFrameworkCore" Version="10.1.0" />
     <PackageVersion Include="Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection" Version="10.1.0" />
     <PackageVersion Include="Paramore.Brighter.ServiceActivator.Extensions.Hosting" Version="10.1.0" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.14" />
     <PackageVersion Include="Serialize.Linq" Version="4.0.167" />
     <PackageVersion Include="ReportGenerator" Version="5.5.10" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />

--- a/src/Agenda.API/Agenda.API.csproj
+++ b/src/Agenda.API/Agenda.API.csproj
@@ -43,6 +43,7 @@
     <PackageReference Include="Paramore.Brighter.PostgreSql.EntityFrameworkCore" />
     <PackageReference Include="Paramore.Brighter.ServiceActivator.Extensions.DependencyInjection" />
     <PackageReference Include="Paramore.Brighter.ServiceActivator.Extensions.Hosting" />
+    <PackageReference Include="Scalar.AspNetCore" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.Seq" />

--- a/src/Agenda.API/Program.cs
+++ b/src/Agenda.API/Program.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Http.Json;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using NodaTime.Serialization.SystemTextJson;
+using Scalar.AspNetCore;
 using Serilog;
 using SystemTextJsonPatch.Operations;
 using static Microsoft.AspNetCore.Http.StatusCodes;
@@ -116,8 +117,10 @@ app.UseFastEndpoints(config =>
                                                          });
 
                          optionsSerializerSettings.Invoke(config.Serializer.Options);
-                     })
-    .UseSwaggerGen();
+                     });
+
+app.UseOpenApi(options => options.Path = "/openapi/{documentName}.json");
+app.MapScalarApiReference(options => options.AddDocument("v1"));
 
 app.MapDefaultEndpoints();
 

--- a/src/Agenda.API/Properties/launchSettings.json
+++ b/src/Agenda.API/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "hotReloadEnabled": true,
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
@@ -14,7 +14,7 @@
       "hotReloadEnabled": true,
       "commandName": "Docker",
       "launchBrowser": true,
-      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/scalar",
       "publishAllPorts": true
     }
   }

--- a/src/Agenda.API/appsettings.IntegrationTest.json
+++ b/src/Agenda.API/appsettings.IntegrationTest.json
@@ -16,13 +16,6 @@
       "OutboxTablename" : "Outbox"
     }
   },
-  "Swagger": {
-    "Contact": {
-      "Email": "ndoumbecyrille@hotmail.com",
-      "Name": "Cyrille NDOUMBE",
-      "Url": "https://github.com/candoumbe/MedEasy/Documents.API"
-    }
-  },
   "Authentication": {
     "JwtOptions": {
       "Issuer": "identity.api",

--- a/src/Agenda.API/appsettings.json
+++ b/src/Agenda.API/appsettings.json
@@ -25,11 +25,5 @@
     "Messaging": {
       "OutboxTableName": "Outbox",
     }
-  },
-  "Swagger": {
-    "Contact": {
-      "Email": "ndoumbecyrille@hotmail.com",
-      "Name": "Cyrille-Alexandre NDOUMBE"
-    }
   }
 }

--- a/tests/Agenda.API.IntegrationTests/ApiDocumentationShould.cs
+++ b/tests/Agenda.API.IntegrationTests/ApiDocumentationShould.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Agenda.API.IntegrationTests.Fixtures;
+using AwesomeAssertions;
+using Xunit;
+using Xunit.OpenCategories.V3;
+
+namespace Agenda.API.IntegrationTests;
+
+[IntegrationTest]
+public sealed class ApiDocumentationShould
+{
+    private readonly HttpClient _client;
+
+    public ApiDocumentationShould(AgendaApplicationFixture fixture)
+    {
+        _client = fixture.ApiClient;
+    }
+
+    [Fact]
+    public async Task Expose_api_documentation_from_scalar_endpoint()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        // Act
+        using HttpResponseMessage scalarResponse = await _client.GetAsync("/scalar", cancellationToken);
+        using HttpResponseMessage versionedScalarResponse = await _client.GetAsync("/scalar/v1", cancellationToken);
+
+        // Assert
+        bool scalarEndpointExists = IsSuccessfulOrRedirectStatusCode(scalarResponse.StatusCode);
+        bool versionedScalarEndpointExists = IsSuccessfulOrRedirectStatusCode(versionedScalarResponse.StatusCode);
+        bool documentationExposedFromScalar = scalarEndpointExists || versionedScalarEndpointExists;
+
+        documentationExposedFromScalar.Should().BeTrue(
+            "API documentation should be served by Scalar from either /scalar or /scalar/v1");
+    }
+
+    [Fact]
+    public async Task Not_expose_swagger_ui_endpoint_anymore()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        // Act
+        using HttpResponseMessage response = await _client.GetAsync("/swagger", cancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "Swagger UI endpoint should not be available once Scalar migration is complete");
+    }
+
+    [Fact]
+    public async Task Expose_openapi_document_for_v1()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        // Act
+        using HttpResponseMessage response = await _client.GetAsync("/openapi/v1.json", cancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "OpenAPI v1 JSON document should remain available for Scalar and API consumers");
+
+        MediaTypeHeaderValue contentType = response.Content.Headers.ContentType
+            ?? throw new InvalidOperationException("OpenAPI response should provide a content type header");
+        contentType.MediaType.Should().Be("application/json");
+
+        string payload = await response.Content.ReadAsStringAsync(cancellationToken);
+        using JsonDocument document = JsonDocument.Parse(payload);
+        bool hasOpenApiVersion = document.RootElement.TryGetProperty("openapi", out JsonElement openApiProperty)
+            && !string.IsNullOrWhiteSpace(openApiProperty.GetString());
+        hasOpenApiVersion.Should().BeTrue("generated document should expose a valid OpenAPI version field");
+    }
+
+    private static bool IsSuccessfulOrRedirectStatusCode(HttpStatusCode statusCode)
+    {
+        bool isSuccessful = statusCode is >= HttpStatusCode.OK and < HttpStatusCode.MultipleChoices;
+        bool isRedirect = statusCode is HttpStatusCode.Moved
+            or HttpStatusCode.Redirect
+            or HttpStatusCode.RedirectMethod
+            or HttpStatusCode.TemporaryRedirect
+            or HttpStatusCode.PermanentRedirect;
+
+        bool result = isSuccessful || isRedirect;
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
- Replace Swagger UI with Scalar API Reference in the API host configuration.
- Keep the OpenAPI JSON document publicly available for consumers at `/openapi/v1.json`.
- Update API launch profiles to open Scalar instead of Swagger.
- Add integration coverage for documentation endpoints: Scalar is reachable, Swagger UI is not exposed, and OpenAPI JSON remains valid.
- Update changelog entry for issue #571.

## Validation
- `dotnet test tests/Agenda.API.IntegrationTests/Agenda.API.IntegrationTests.csproj -- --filter-class Agenda.API.IntegrationTests.ApiDocumentationShould`
  - Passed: 3/3 tests
- `dotnet test tests/Agenda.API.IntegrationTests/Agenda.API.IntegrationTests.csproj --verbosity normal`
  - Failed: 1/25 tests (unrelated infrastructure health check failure: `messaging_check` / RabbitMQ end-of-stream in test environment)

Closes #571