### PR TITLE
docs(adr): add ADR template

### DIFF
--- a/docs/ADRs/000-template.md
+++ b/docs/ADRs/000-template.md
@@ -1,0 +1,58 @@
+# ADR-{NNN}: {Title}
+
+## Status
+
+{Proposed | Accepted | Deprecated | Superseded by [ADR-XXX](XXX-title.md)}
+
+## Date
+
+{YYYY-MM-DD}
+
+## Context
+
+{Describe the problem, need, or constraint that motivates this decision. Include relevant background information, technical context, and any requirements that must be satisfied.}
+
+## Options Considered
+
+### 1. {Option Name}
+
+{Brief description of the option.}
+
+**Pros:**
+
+- {Advantage 1}
+- {Advantage 2}
+
+**Cons:**
+
+- {Disadvantage 1}
+- {Disadvantage 2}
+
+### 2. {Option Name}
+
+{Brief description of the option.}
+
+**Pros:**
+
+- {Advantage 1}
+- {Advantage 2}
+
+**Cons:**
+
+- {Disadvantage 1}
+- {Disadvantage 2}
+
+## Decision
+
+We choose **{Option Name}** {brief statement of what was decided}.
+
+## Rationale
+
+1. **{Reason title}:** {Explanation linking back to context/requirements.}
+2. **{Reason title}:** {Explanation.}
+
+## Consequences
+
+- {Consequence or follow-up action 1.}
+- {Consequence or follow-up action 2.}
+- {Consequence or follow-up action 3.}


### PR DESCRIPTION
## Summary
- add a reusable ADR template inspired by ADR-001
- define the standard sections for all future ADRs

## Validation
- not run (documentation-only change)