### PR TITLE
feat(auth): Keycloak phase 1 — AppHost & realm provisioning (#576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added integration coverage for appointments `HEAD` contracts on `GET /appointments/{id}` and paginated `GET /appointments` responses
 - Made appointments search case-insensitive at database level by switching `Subject` and `Location` to PostgreSQL `citext` columns ([#504](https://github.com/candoumbe/agenda/issues/504))
 
+#### AppHost
+- Aspire AppHost now provisions a Keycloak resource (`keycloak`) with an imported `agenda` realm including dev users `alice` and `admin`. ([#576](https://github.com/candoumbe/agenda/issues/576), [#323](https://github.com/candoumbe/agenda/issues/323))
+
 ### 📝 Documentation
 - Added ADR-001: Authentication provider selection (Keycloak) ([#323](https://github.com/candoumbe/agenda/issues/323))
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.5" />
     <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.3.5" />
+    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="13.3.5-preview.1.26270.6" />
     <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.3.5" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.5" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.5" />

--- a/src/Agenda.AppHost/Agenda.AppHost.csproj
+++ b/src/Agenda.AppHost/Agenda.AppHost.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost"/>
     <PackageReference Include="Aspire.Hosting.JavaScript" />
+    <PackageReference Include="Aspire.Hosting.Keycloak" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL"/>
     <PackageReference Include="Aspire.Hosting.RabbitMQ"/>
   </ItemGroup>
@@ -19,6 +20,11 @@
   <ItemGroup>
     <ProjectReference Include="..\Agenda.API\Agenda.API.csproj" />
     <ProjectReference Include="..\Agenda.Migrator\Agenda.Migrator.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="keycloak\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="keycloak\**\*.md" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/Agenda.AppHost/AppHost.cs
+++ b/src/Agenda.AppHost/AppHost.cs
@@ -21,6 +21,18 @@ if (builder.ExecutionContext.IsRunMode && !isRunningIntegrationTests)
 var messaging = builder.AddRabbitMQ("messaging")
     .WithManagementPlugin();
 
+IResourceBuilder<ParameterResource> keycloakAdminUser = builder.AddParameter("keycloak-admin-user", secret: true);
+IResourceBuilder<ParameterResource> keycloakAdminPassword = builder.AddParameter("keycloak-admin-password", secret: true);
+
+IResourceBuilder<KeycloakResource> keycloak = builder.AddKeycloak("keycloak", adminUsername: keycloakAdminUser, adminPassword: keycloakAdminPassword)
+    .WithImageTag("26.x")
+    .WithRealmImport("./keycloak/agenda-realm.json");
+
+if (!isRunningIntegrationTests)
+{
+    keycloak = keycloak.WithDataVolume("keycloak-data");
+}
+
 IResourceBuilder<ProjectResource> migrationService = builder.AddProject<Agenda_Migrator>("migrations")
     .WithReference(postgres)
     .WaitFor(postgres);
@@ -31,6 +43,7 @@ IResourceBuilder<ProjectResource> api = builder.AddProject<Agenda_API>("api")
     .WithExternalHttpEndpoints()
     .WithReference(postgres).WaitFor(postgres)
     .WithReference(messaging).WaitFor(messaging)
+    .WithReference(keycloak).WaitFor(keycloak)
     .WaitForCompletion(migrationService);
 
 if (!string.IsNullOrWhiteSpace(testingNow))
@@ -56,6 +69,8 @@ if (!isRunningIntegrationTests)
               .WithDeveloperCertificateTrust(trust: true)
               .WithReference(api)
               .WaitFor(api)
+              .WithReference(keycloak)
+              .WaitFor(keycloak)
                 // Demande à Aspire d’allouer un port et de le passer à l’app via la variable d’env PORT
               .WithHttpEndpoint(env: "PORT")
               .WithExternalHttpEndpoints()

--- a/src/Agenda.AppHost/AppHost.cs
+++ b/src/Agenda.AppHost/AppHost.cs
@@ -25,7 +25,6 @@ IResourceBuilder<ParameterResource> keycloakAdminUser = builder.AddParameter("ke
 IResourceBuilder<ParameterResource> keycloakAdminPassword = builder.AddParameter("keycloak-admin-password", secret: true);
 
 IResourceBuilder<KeycloakResource> keycloak = builder.AddKeycloak("keycloak", adminUsername: keycloakAdminUser, adminPassword: keycloakAdminPassword)
-    .WithImageTag("26.x")
     .WithRealmImport("./keycloak/agenda-realm.json");
 
 if (!isRunningIntegrationTests)

--- a/src/Agenda.AppHost/keycloak/README.md
+++ b/src/Agenda.AppHost/keycloak/README.md
@@ -1,0 +1,65 @@
+# Keycloak realm — `agenda`
+
+This folder contains the Keycloak configuration imported by the Aspire AppHost when it
+provisions the `keycloak` resource.
+
+## Files
+
+- [agenda-realm.json](agenda-realm.json) — full realm export consumed by `WithRealmImport(...)`.
+
+## Realm summary
+
+- Realm: `agenda`
+- Realm roles: `agenda-user` (default), `agenda-admin`, `agenda-service-account`
+- Clients:
+  - `agenda-frontend` — public, Authorization Code + PKCE (S256), Direct Access Grants enabled (dev only).
+  - `agenda-mobile` — public, Authorization Code + PKCE (S256), custom-scheme redirect URI.
+  - `agenda-api` — bearer-only, audience target.
+  - `agenda-service` — confidential, `client_credentials` (service account) with `agenda-service-account` role.
+- Audience and realm-roles flatten mappers are exposed through the `agenda-audience` client scope and
+  attached to `agenda-frontend`, `agenda-mobile`, and `agenda-service`.
+- Token lifetimes: access token `300s` (5 min), SSO idle `1800s` (30 min), SSO max `28800s` (8 h).
+
+## Dev users (DEV ONLY — passwords are seeded for local development)
+
+| Username | Password   | Realm roles                  |
+|----------|------------|------------------------------|
+| `alice`  | `password` | `agenda-user`                |
+| `admin`  | `password` | `agenda-user`, `agenda-admin`|
+
+> ⚠️ The seeded passwords above must never be reused outside local dev / integration tests.
+
+## Re-export workflow
+
+When the realm is updated through the Keycloak admin console, re-export it to keep this file
+as the single source of truth.
+
+1. Open a shell into the running `keycloak` container started by Aspire:
+
+   ```bash
+   docker exec -it <keycloak-container> /opt/keycloak/bin/kc.sh export \
+     --realm agenda \
+     --file /tmp/agenda-realm.json \
+     --users realm_file
+   ```
+
+2. Copy the export back to this folder:
+
+   ```bash
+   docker cp <keycloak-container>:/tmp/agenda-realm.json src/Agenda.AppHost/keycloak/agenda-realm.json
+   ```
+
+3. Review the diff carefully — Keycloak adds environment-specific `id` fields and timestamps that
+   should be normalized before committing.
+
+## Re-import workflow
+
+The realm is automatically re-imported by Aspire on every AppHost startup through
+`WithRealmImport("./keycloak/agenda-realm.json")`. To force a clean re-import locally, delete the
+`keycloak-data` volume:
+
+```bash
+docker volume rm keycloak-data
+```
+
+Then restart the AppHost.

--- a/src/Agenda.AppHost/keycloak/agenda-realm.json
+++ b/src/Agenda.AppHost/keycloak/agenda-realm.json
@@ -1,0 +1,223 @@
+{
+  "realm": "agenda",
+  "enabled": true,
+  "displayName": "Agenda",
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": true,
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 28800,
+  "defaultRole": {
+    "name": "agenda-user",
+    "description": "Default role assigned to every authenticated agenda user",
+    "composite": false,
+    "clientRole": false
+  },
+  "roles": {
+    "realm": [
+      {
+        "name": "agenda-user",
+        "description": "Standard agenda user role"
+      },
+      {
+        "name": "agenda-admin",
+        "description": "Agenda administrator role"
+      },
+      {
+        "name": "agenda-service-account",
+        "description": "Role assigned to the agenda-service service account for service-to-service calls"
+      }
+    ]
+  },
+  "clientScopes": [
+    {
+      "name": "agenda-audience",
+      "description": "Adds agenda-api as audience and flattens realm_access.roles into the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "agenda-api-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "agenda-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "realm-roles-flatten",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "agenda-frontend",
+      "name": "Agenda Frontend (Angular SPA)",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "https://localhost:*",
+        "http://localhost:*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "+"
+      },
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email",
+        "agenda-audience"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "clientId": "agenda-mobile",
+      "name": "Agenda Mobile",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "agenda://callback",
+        "agenda://*"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "agenda://*"
+      },
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email",
+        "agenda-audience"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "clientId": "agenda-api",
+      "name": "Agenda API (resource server)",
+      "enabled": true,
+      "bearerOnly": true,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "defaultClientScopes": [
+        "profile",
+        "roles",
+        "email"
+      ]
+    },
+    {
+      "clientId": "agenda-service",
+      "name": "Agenda Service (machine-to-machine)",
+      "enabled": true,
+      "publicClient": false,
+      "secret": "agenda-service-dev-secret",
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "defaultClientScopes": [
+        "profile",
+        "roles",
+        "email",
+        "agenda-audience"
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "alice",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alice",
+      "lastName": "Doe",
+      "email": "alice@agenda.local",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "agenda-user"
+      ]
+    },
+    {
+      "username": "admin",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Admin",
+      "lastName": "Doe",
+      "email": "admin@agenda.local",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "agenda-user",
+        "agenda-admin"
+      ]
+    },
+    {
+      "username": "service-account-agenda-service",
+      "enabled": true,
+      "serviceAccountClientId": "agenda-service",
+      "realmRoles": [
+        "agenda-service-account"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #576. Sub-task of #323.

Implements Phase 1 of the Keycloak authentication plan: provisions a Keycloak resource via Aspire AppHost with an imported `agenda` realm (clients agenda-frontend / agenda-mobile / agenda-api / agenda-service, roles agenda-user/agenda-admin/agenda-service-account, dev users alice & admin).

Deviation from plan: `Aspire.Hosting.Keycloak` only ships as preview at the 13.x band, so the package is pinned to `13.3.5-preview.1.26270.6` (matching commit/build hash of the stable Aspire 13.3.5 release).

See docs/plans/keycloak-authentication-plan.md.