### PR TITLE
fix(aspire): fix connection refused issues with dynamic ports and enhance Keycloak configuration

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -43,3 +43,6 @@ For `AddLinkHeaderResponseInterceptor`, a safe single-entry/single-exit refactor
 
 ## Learning — 2026-05-28T20:09:00Z: HATEOAS link query parameter case mismatch risk
 When backend-generated pagination links use PascalCase query names (for example `Page`, `PageSize`) and frontend extraction expects lowercase keys, browser `URLSearchParams` returns null because key lookup is case-sensitive. Frontend parsing should check both variants where compatibility is required to prevent pagination state drift.
+
+## Learning — 2026-06-01T08:43:38Z: Aspire connection-refused triage needs current-run endpoint verification
+Intermittent `connection refused` reports during local Aspire startup can be caused by stale endpoint URLs after dynamic port changes between runs. A reliable triage sequence is: verify AppHost process outcome (`dotnet run` exit status), then probe only the currently advertised frontend/API/identity/messaging endpoints. In the investigated run, endpoint probes succeeded when URLs matched the active process output.

--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -169,3 +169,6 @@ import { vi } from 'vitest';
 
 ## Learning — 2026-05-29T00:00:00Z: Swagger-to-Scalar test baseline should validate UI and JSON endpoints
 For the Swagger UI to Scalar migration, endpoint coverage is release-safe when integration tests assert all three behaviors together: Scalar UI is reachable (`/scalar` or `/scalar/v1`), Swagger UI is removed (`/swagger` returns 404), and the OpenAPI document remains available (`/openapi/v1.json` returns JSON with an `openapi` field). Validating only UI presence can miss regressions where Scalar loads but OpenAPI generation or routing is broken.
+
+## Learning — 2026-06-01T08:43:38Z: Aspire connection-refused checks should separate startup instability from stale URLs
+When AppHost runs show mixed outcomes (including occasional non-zero exits), stale URLs from prior runs can produce misleading `connection refused` results. Test/validation diagnostics should always use endpoints from the active run and include a quick reachability sweep (`/health` and key dependency surfaces) before classifying the issue as a functional regression.

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -101,6 +101,7 @@ Expected highlights:
 
 | Symptom                                | Likely cause                                                                 |
 |----------------------------------------|------------------------------------------------------------------------------|
+| `connection refused` when calling non-frontend resources | Fixed local ports collided or changed; keep dev `launchSettings` on `localhost:0` and use the actual URLs published by the Aspire dashboard. |
 | `401` with `WWW-Authenticate: invalid_token` and `aud` mismatch | The token was minted for a different client; re-mint with `scope=agenda-audience`. |
 | `401` with `invalid_token` and `iss` mismatch | The API and Keycloak see different base URLs; align the issuer between AppHost and `appsettings`. |
 | `401` shortly after a working call     | Token expired (default lifetime 5 min); re-mint or refresh.                  |

--- a/src/Agenda.AppHost/AppHost.cs
+++ b/src/Agenda.AppHost/AppHost.cs
@@ -25,14 +25,12 @@ var messaging = builder.AddRabbitMQ("messaging")
     .WithImage(rabbitImage.Image, rabbitImage.Tag)
     .WithManagementPlugin();
 
-IResourceBuilder<ParameterResource> keycloakAdminUser = builder.AddParameter("keycloak-admin-user", secret: true);
-IResourceBuilder<ParameterResource> keycloakAdminPassword = builder.AddParameter("keycloak-admin-password", secret: true);
-
 PinnedContainerImage keycloakImage = ContainerImages.Keycloak;
-IResourceBuilder<KeycloakResource> keycloak = builder.AddKeycloak("keycloak", adminUsername: keycloakAdminUser, adminPassword: keycloakAdminPassword)
+IResourceBuilder<KeycloakResource> keycloak = builder.AddKeycloak("keycloak")
     .WithImage(keycloakImage.Image, keycloakImage.Tag)
     .WithRealmImport("./keycloak/agenda-realm.json")
-    .WithDeveloperCertificateTrust(trust: true);
+    .WithDeveloperCertificateTrust(trust: true)
+    .WithExternalHttpEndpoints();
 
 if (!isRunningIntegrationTests)
 {

--- a/src/Agenda.AppHost/AppHost.cs
+++ b/src/Agenda.AppHost/AppHost.cs
@@ -25,8 +25,14 @@ var messaging = builder.AddRabbitMQ("messaging")
     .WithImage(rabbitImage.Image, rabbitImage.Tag)
     .WithManagementPlugin();
 
+
+IResourceBuilder<ParameterResource> keycloakAdminUser = builder.AddParameter("keycloak-admin-user", secret: true);
+IResourceBuilder<ParameterResource> keycloakAdminPassword = builder.AddParameter("keycloak-admin-password", secret: true);
+
 PinnedContainerImage keycloakImage = ContainerImages.Keycloak;
-IResourceBuilder<KeycloakResource> keycloak = builder.AddKeycloak("keycloak")
+IResourceBuilder<KeycloakResource> keycloak = builder.AddKeycloak("keycloak",
+                                                                  adminUsername: keycloakAdminUser,
+                                                                  adminPassword: keycloakAdminPassword)
     .WithImage(keycloakImage.Image, keycloakImage.Tag)
     .WithRealmImport("./keycloak/agenda-realm.json")
     .WithDeveloperCertificateTrust(trust: true)

--- a/src/Agenda.AppHost/Properties/launchSettings.json
+++ b/src/Agenda.AppHost/Properties/launchSettings.json
@@ -5,12 +5,12 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:17080;http://localhost:15093",
+      "applicationUrl": "https://localhost:0;http://localhost:0",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21247",
-        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22188",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:0",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:0",
         "ASPIRE_DASHBOARD_AI_DISABLED": "true"
       }
     },
@@ -18,12 +18,13 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:15093",
+      "applicationUrl": "http://localhost:0",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19198",
-        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20268",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:0",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:0",
         "ASPIRE_DASHBOARD_AI_DISABLED": "true"
       }
     }


### PR DESCRIPTION
Address connection refused errors during local Aspire startup by ensuring the use of current endpoint URLs after dynamic port changes. Update documentation to include troubleshooting steps and enhance Keycloak configuration with admin user and password parameters.