### PR TITLE
feat: add creator username to appointment creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added RabbitMQ integration and related configuration.
 - Added publication of `AppointmentScheduled` event when a new appointment is scheduled : 
 - Added publication of `AppointmentCreated` event when a new appointment is created, containing appointment ID, start/end dates (ISO 8601), location, attendees list, and creator ID (#329)
+- Updated appointment creation flow to persist and publish the authenticated creator username (`preferred_username`) instead of the static `system` value
+- Added auditable appointment API resource fields to expose creator metadata on create responses
 - Added healthchecks for PostgreSQL and RabbitMQ
 - Migrated API documentation UI from Swagger UI to Scalar while keeping the OpenAPI JSON document available ([#571](https://github.com/candoumbe/agenda/issues/571))
 - Updated appointments paginated headers contract for UI navigation: `total` now represents the total number of matching elements, `count` represents the number of elements in the current page, and redundant `totalCount` was removed
@@ -56,6 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default authorization policy now requires an authenticated user but OpenAPI/Scalar routes remain anonymous in non-Production environments only. ([#577](https://github.com/candoumbe/agenda/issues/577))
 - Removed the symmetric `JwtOptions` configuration in favor of Keycloak OIDC discovery. ([#577](https://github.com/candoumbe/agenda/issues/577))
 - All API endpoints now require authentication by default. `DELETE /appointments/{id}` additionally requires the `agenda-admin` realm role. ([#578](https://github.com/candoumbe/agenda/issues/578), [#323](https://github.com/candoumbe/agenda/issues/323))
+- Added unit coverage for `Username` value object validation and conversion
+- Updated appointment creation unit tests to assert creator propagation from request metadata to emitted events and API response
 
 ### 📝 Documentation
 - Added [docs/development/authentication.md](docs/development/authentication.md) describing the local Keycloak setup, seeded dev users, token-fetch recipes (Direct Access Grant, `client_credentials`), token inspection, and troubleshooting. ([#580](https://github.com/candoumbe/agenda/issues/580), [#323](https://github.com/candoumbe/agenda/issues/323))
@@ -80,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added dotnet devcontainer feature to manage .NET versions
 - Updated AppHost launch settings to bind Aspire local service endpoints to `127.0.0.1` instead of `localhost`
 - Updated `Candoumbe.Pipelines` package to `3.0.1`
+- Enabled NuGet central transitive pinning and pinned `SQLitePCLRaw.lib.e_sqlite3` to a non-vulnerable version to address NU1903
 
 ## [0.1.0] / 2025-10-03
 ### 🚀 New features

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/candoumbe/agenda</RepositoryUrl>
   </PropertyGroup>
@@ -97,6 +97,8 @@
     <PackageVersion Include="Serilog.Sinks.Seq" Version="9.1.0" />
     <PackageVersion Include="StronglyTypedId" Version="1.0.0-beta08" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageVersion Include="StronglyTypedId.Templates" Version="1.0.0-beta08" PrivateAssets="all" ExcludeAssets="runtime;compile" />
+    <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.3" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageVersion Include="System.Text.Json" Version="10.0.9" />
     <PackageVersion Include="SystemTextJsonPatch" Version="5.0.0" />

--- a/src/Agenda.API/CurrentRequestMetadataInfoProvider.cs
+++ b/src/Agenda.API/CurrentRequestMetadataInfoProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Security.Claims;
+using Agenda.Objects;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
@@ -82,9 +83,9 @@ public class CurrentRequestMetadataInfoProvider
     /// Gets the current authenticated user name from the <c>preferred_username</c> claim.
     /// </summary>
     /// <returns>The user name or an empty string when no claim is available.</returns>
-    public string GetCurrentUserName()
+    public virtual Username GetCurrentUserName()
     {
-        string userName = string.Empty;
+        Username userName = Username.Empty;
         ClaimsPrincipal user = _httpContextAccessor.HttpContext?.User;
 
         if (user is not null)
@@ -93,7 +94,7 @@ public class CurrentRequestMetadataInfoProvider
 
             if (nameClaim is not null && !string.IsNullOrWhiteSpace(nameClaim.Value))
             {
-                userName = nameClaim.Value;
+                userName = Username.FromString(nameClaim.Value);
             }
         }
 

--- a/src/Agenda.API/Features/Appointments/AppointmentInfo.cs
+++ b/src/Agenda.API/Features/Appointments/AppointmentInfo.cs
@@ -8,7 +8,7 @@ namespace Agenda.API.Features.Appointments;
 /// <summary>
 /// An appointment between two or more people
 /// </summary>
-public record AppointmentInfo : Resource<AppointmentId>
+public record AppointmentInfo : AuditableResource<AppointmentId>
 {
     /// <summary>
     /// Location of the appointment
@@ -33,7 +33,7 @@ public record AppointmentInfo : Resource<AppointmentId>
     /// <summary>
     /// Defines who initiated the appointment
     /// </summary>
-    public AttendeeInfo Iniator { get; init; }
+    public AttendeeInfo Initiator { get; init; }
 
     /// <summary>
     /// Participants

--- a/src/Agenda.API/Features/Appointments/v1/Create/CreateAppointmentEndpoint.cs
+++ b/src/Agenda.API/Features/Appointments/v1/Create/CreateAppointmentEndpoint.cs
@@ -64,6 +64,8 @@ public partial class CreateAppointmentEndpoint : Endpoint<NewAppointmentInfo, Cr
         IReadOnlyList<AttendeeInfo> attendees = req.Attendees ?? [];
 
         Appointment newAppointment = new(req.Id, req.Subject, req.Location, req.StartDate.ToInstant(), req.EndDate.ToInstant());
+        Username username = _currentRequestMetadataInfoProvider.GetCurrentUserName();
+        newAppointment.WasCreatedBy(username);
         foreach (AttendeeInfo attendee in attendees)
         {
             newAppointment.AddAttendee(new Attendee(attendee.Id, attendee.Name, attendee.Email, attendee.PhoneNumber));
@@ -95,7 +97,7 @@ public partial class CreateAppointmentEndpoint : Endpoint<NewAppointmentInfo, Cr
                                                                             LastName = a.Email
                                                                         })
                                                          ],
-                                                         "system");
+                                                         newAppointment.CreatedBy);
 
         await _commandProcessor.DepositPostAsync(appointmentScheduledEvent, cancellationToken: ct);
         await _commandProcessor.DepositPostAsync(appointmentCreatedEvent, cancellationToken: ct);
@@ -109,7 +111,8 @@ public partial class CreateAppointmentEndpoint : Endpoint<NewAppointmentInfo, Cr
             StartDate = newAppointment.StartDate.InZone(zone).ToOffsetDateTime(),
             EndDate = newAppointment.EndDate.InZone(zone).ToOffsetDateTime(),
             Subject = newAppointment.Subject,
-            Attendees = attendees
+            Attendees = attendees,
+            CreatedBy = username,
         };
 
         Browsable<AppointmentInfo> browsable = new()

--- a/src/Agenda.API/Features/AuditableResource.cs
+++ b/src/Agenda.API/Features/AuditableResource.cs
@@ -18,7 +18,7 @@ public record AuditableResource<TId> : Resource<TId> where TId : IComparable<TId
     /// <summary>
     /// The username of the user who created the resource.
     /// </summary>
-    public Username CreatedBy { get; init; }
+    public string CreatedBy { get; init; }
 
     /// <summary>
     /// The date and time when the resource was last updated.
@@ -28,5 +28,5 @@ public record AuditableResource<TId> : Resource<TId> where TId : IComparable<TId
     /// <summary>
     /// The username of the user who last updated the resource.
     /// </summary>
-    public Username UpdatedBy { get; init; }
+    public string UpdatedBy { get; init; }
 }

--- a/src/Agenda.API/Features/AuditableResource.cs
+++ b/src/Agenda.API/Features/AuditableResource.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Agenda.Objects;
+using NodaTime;
+
+namespace Agenda.API.Features;
+
+/// <summary>
+/// Represents a resource
+/// </summary>
+/// <typeparam name="TId">Type of the resource's identifier.</typeparam>
+public record AuditableResource<TId> : Resource<TId> where TId : IComparable<TId>
+{
+    /// <summary>
+    /// The date and time when the resource was created.
+    /// </summary>
+    public Instant CreatedAt { get; init; }
+
+    /// <summary>
+    /// The username of the user who created the resource.
+    /// </summary>
+    public Username CreatedBy { get; init; }
+
+    /// <summary>
+    /// The date and time when the resource was last updated.
+    /// </summary>
+    public Instant? UpdatedAt { get; init; }
+
+    /// <summary>
+    /// The username of the user who last updated the resource.
+    /// </summary>
+    public Username UpdatedBy { get; init; }
+}

--- a/src/Agenda.API/Program.cs
+++ b/src/Agenda.API/Program.cs
@@ -107,10 +107,10 @@ app.UseFastEndpoints(config =>
                             }
 
                             return addLinkHeaderResponseInterceptor.InterceptResponseAsync(response,
-                                                                                            httpContext.Response.StatusCode,
-                                                                                            httpContext,
-                                                                                            Array.Empty<ValidationFailure>(),
-                                                                                            httpContext.RequestAborted);
+                                                                                           httpContext.Response.StatusCode,
+                                                                                           httpContext,
+                                                                                           [],
+                                                                                           httpContext.RequestAborted);
                          };
 
                          config.Errors.UseProblemDetails(detailsConfig =>

--- a/src/Agenda.Objects/Appointment.cs
+++ b/src/Agenda.Objects/Appointment.cs
@@ -143,4 +143,14 @@ public class Appointment : AuditableEntity<AppointmentId, Appointment>
     /// </summary>
     /// <param name="newLocation">The new location.</param>
     public void RelocateTo(string newLocation) => Location = newLocation;
+
+
+    /// <summary>
+    /// Defines who created the appointment
+    /// </summary>
+    /// <param name="username">The username of the creator of the appointment</param>
+    public void WasCreatedBy(Username username)
+    {
+        CreatedBy = username;
+    }
 }

--- a/src/Agenda.Objects/Username.cs
+++ b/src/Agenda.Objects/Username.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Agenda.Objects;
+
+public record Username
+{
+
+    /// <summary>
+    /// The username value.
+    /// </summary>
+    public string Value { get; }
+
+    private Username(string value)
+    {
+        Value = value;
+    }
+
+    public static Username Empty => new(string.Empty);
+
+    /// <summary>
+    /// Implicitly converts a <see cref="Username"/> to a <see cref="string"/>.
+    /// </summary>
+    /// <param name="username">The <see cref="Username"/> instance.</param>
+    public static implicit operator string(Username username) => username.Value;
+
+    /// <summary>
+    /// Creates a new <see cref="Username"/> from the specified <paramref name="username"/> string.
+    /// </summary>
+    /// <param name="username">The username string.</param>
+    /// <returns>A new <see cref="Username"/> instance.</returns>
+    /// <exception cref="ArgumentException">Thrown if the <paramref name="username"/> is <see langword="null"/> or whitespace.</exception>
+    public static Username FromString(string username)
+    {
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            throw new ArgumentException("Username cannot be null or whitespace", nameof(username));
+        }
+
+        return new(username);
+    }
+}

--- a/src/Agenda.Objects/Username.cs
+++ b/src/Agenda.Objects/Username.cs
@@ -2,9 +2,11 @@ using System;
 
 namespace Agenda.Objects;
 
+/// <summary>
+/// Represents a username in the system.
+/// </summary>
 public record Username
 {
-
     /// <summary>
     /// The username value.
     /// </summary>
@@ -15,6 +17,9 @@ public record Username
         Value = value;
     }
 
+    /// <summary>
+    /// Represents an empty <see cref="Username"/> instance.
+    /// </summary>
     public static Username Empty => new(string.Empty);
 
     /// <summary>

--- a/tests/Agenda.API.UnitTests/Authentication/CurrentRequestMetadataInfoProviderShould.cs
+++ b/tests/Agenda.API.UnitTests/Authentication/CurrentRequestMetadataInfoProviderShould.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Security.Claims;
+using Agenda.Objects;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -92,10 +93,10 @@ namespace Agenda.API.UnitTests.Authentication
             GivenUser(new Claim("sub", Guid.NewGuid().ToString()));
 
             // Act
-            string actual = _sut.GetCurrentUserName();
+            Username actual = _sut.GetCurrentUserName();
 
             // Assert
-            actual.Should().BeEmpty();
+            actual.Should().Be(Username.Empty);
         }
 
         [Fact]

--- a/tests/Agenda.API.UnitTests/Features/Appointments/v1/Create/CreateAppointementEndpointShould.cs
+++ b/tests/Agenda.API.UnitTests/Features/Appointments/v1/Create/CreateAppointementEndpointShould.cs
@@ -14,6 +14,7 @@ using Agenda.Ids;
 using Agenda.Objects;
 using Agenda.UnitTests.Helpers;
 using AwesomeAssertions;
+using AwesomeAssertions.Common;
 using Bogus;
 using Candoumbe.DataAccess.Abstractions;
 using Candoumbe.Forms;
@@ -22,6 +23,7 @@ using FastEndpoints;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Routing;
+using NodaTime;
 using Paramore.Brighter;
 using Xunit;
 using Xunit.OpenCategories.V3;
@@ -41,6 +43,8 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
         private readonly IUnitOfWork _unitOfWork;
         private readonly IRepository<Appointment> _repository;
 
+        private readonly Username _currentUserName;
+
         static CreateAppointementEndpointShould()
         {
             s_faker = new Faker();
@@ -54,9 +58,13 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
 
         public CreateAppointementEndpointShould()
         {
+            _currentUserName = Username.FromString(s_faker.Internet.UserName());
             _unitOfWorkFactory = A.Fake<IUnitOfWorkFactory>();
             _linkGenerator = A.Fake<LinkGenerator>();
-            _currentRequestMetadataInfoProvider = A.Fake<CurrentRequestMetadataInfoProvider>();
+            _currentRequestMetadataInfoProvider = A.Fake<CurrentRequestMetadataInfoProvider>(x => x.Strict());
+            A.CallTo(() => _currentRequestMetadataInfoProvider.GetCurrentUserName())
+                .Returns(_currentUserName);
+            
             _commandProcessor = A.Fake<IAmACommandProcessor>(x => x.Strict());
             _unitOfWork = A.Fake<IUnitOfWork>(x => x.Strict());
             _repository = A.Fake<IRepository<Appointment>>(x => x.Strict());
@@ -75,11 +83,14 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                                                              _commandProcessor);
         }
 
-        public static TheoryData<GenericSerializable<NewAppointmentInfo>, XunitSerializableExpression<AppointmentInfo>> CreateAppointmentWithValidRequestCases
+        public static TheoryData<GenericSerializable<NewAppointmentInfo>, GenericSerializable<(DateTime Date, Guid UserId, Username Username)>, XunitSerializableExpression<AppointmentInfo>> CreateAppointmentWithValidRequestCases
         {
             get
             {
-                TheoryData<GenericSerializable<NewAppointmentInfo>, XunitSerializableExpression<AppointmentInfo>> cases = new();
+                DateTime dateTime = s_faker.Date.Recent();
+                Guid currentUserId = Guid.CreateVersion7();
+                Username currentUserName = Username.FromString(s_faker.Internet.UserName());
+                TheoryData<GenericSerializable<NewAppointmentInfo>, GenericSerializable<(DateTime, Guid, Username)>, XunitSerializableExpression<AppointmentInfo>> cases = new();
                 // Request with valid data and client side generated id
                 {
                     NewAppointmentInfo req = new()
@@ -92,7 +103,9 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                         Attendees = s_attendeeFaker.Generate(2),
                     };
 
+
                     cases.Add(req,
+                              (dateTime, currentUserId, currentUserName),
                               new XunitSerializableExpression<AppointmentInfo>()
                               {
                                   Value = resource => resource.Id == req.Id
@@ -100,6 +113,7 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                                                       && resource.Location == req.Location
                                                       && resource.StartDate == req.StartDate
                                                       && resource.EndDate == req.EndDate
+                                                      && resource.CreatedBy == currentUserName
                               });
                 }
                 // Request with valid data and server side generated id
@@ -114,6 +128,7 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                     };
 
                     cases.Add(req,
+                              (dateTime, currentUserId, currentUserName),
                               new XunitSerializableExpression<AppointmentInfo>()
                               {
                                   Value = resource => resource.Id != AppointmentId.Empty
@@ -121,6 +136,7 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                                                       && resource.Location == req.Location
                                                       && resource.StartDate == req.StartDate
                                                       && resource.EndDate == req.EndDate
+                                                      && resource.CreatedBy == currentUserName
                               });
                 }
 
@@ -135,6 +151,7 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                     };
 
                     cases.Add(req,
+                              (dateTime, currentUserId, currentUserName),
                               new XunitSerializableExpression<AppointmentInfo>()
                               {
                                   Value = resource => resource.Id != AppointmentId.Empty
@@ -142,6 +159,7 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                                                       && resource.Location == string.Empty
                                                       && resource.StartDate == req.StartDate
                                                       && resource.EndDate == req.EndDate
+                                                      && resource.CreatedBy == currentUserName
                               });
                 }
 
@@ -157,6 +175,7 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                     };
 
                     cases.Add(req,
+                              (dateTime, currentUserId, currentUserName),
                               new XunitSerializableExpression<AppointmentInfo>()
                               {
                                   Value = resource => resource.Id != AppointmentId.Empty
@@ -164,6 +183,7 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                                                       && resource.Location == req.Location
                                                       && resource.StartDate == req.StartDate
                                                       && resource.EndDate == req.EndDate
+                                                      && resource.CreatedBy == currentUserName
                                                       && resource.Attendees != null
                                                       && !resource.Attendees.AtLeastOnce()
                               });
@@ -196,6 +216,7 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
         [Theory]
         [MemberData(nameof(CreateAppointmentWithValidRequestCases))]
         public async Task Create_appointment_when_valid_request_is_received(GenericSerializable<NewAppointmentInfo> req,
+                                                                            GenericSerializable<(DateTime Date, Guid UserId, Username Username)> requestContext,
                                                                             XunitSerializableExpression<AppointmentInfo> responseExpectation)
         {
             // Arrange
@@ -216,6 +237,10 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
 
             A.CallTo(() => _commandProcessor.DepositPostAsync(An<AppointmentCreated>._, A<RequestContext>._, A<Dictionary<string, object>>._, A<bool>._, A<CancellationToken>._))
                 .ReturnsLazily((AppointmentCreated evt, RequestContext _, Dictionary<string, object> _,  bool _, CancellationToken _) => evt.Id);
+
+            A.CallTo(() => _currentRequestMetadataInfoProvider.GetCurrentUserName())
+                .Returns(requestContext.Value.Username);
+
 
             // Act
             CreatedAtRoute<Browsable<AppointmentInfo>> response = await _sut.ExecuteAsync(req, CancellationToken.None);
@@ -249,6 +274,8 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
             A.CallTo(() => _unitOfWork.SaveChangesAsync(A<CancellationToken>._))
                 .MustHaveHappenedOnceExactly();
 
+            A.CallTo(() => _currentRequestMetadataInfoProvider.GetCurrentUserName())
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -326,7 +353,7 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                     && req.Attendees.All(attendee => evt.Attendees.Any(participant =>
                     participant.FirstName == attendee.Name
                         && participant.LastName == attendee.Email))
-                    && evt.CreatorId == "system"),
+                    && evt.CreatorId == _currentUserName),
                 A<RequestContext>._,
                 A<Dictionary<string, object>>._,
                 A<bool>._,
@@ -384,7 +411,7 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
                     && evt.EndDate == req.EndDate.ToInstant()
                     && evt.Location == req.Location
                     && evt.Attendees.Count == 3
-                    && evt.CreatorId == "system"),
+                    && evt.CreatorId == _currentUserName),
                 A<RequestContext>._,
                 A<Dictionary<string, object>>._,
                 A<bool>._,
@@ -494,7 +521,7 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
 
             // Assert
             A.CallTo(() => _commandProcessor.DepositPostAsync(A<AppointmentCreated>.That.Matches(evt =>
-                    evt.Location == string.Empty),
+                    evt.Location == req.Location),
                 A<RequestContext>._,
                 A<Dictionary<string, object>>._,
                 A<bool>._,
@@ -600,7 +627,7 @@ namespace Agenda.API.UnitTests.Features.Appointments.v1.Create
 
             // Assert
             A.CallTo(() => _commandProcessor.DepositPostAsync(A<AppointmentCreated>.That.Matches(evt =>
-                    evt.CreatorId == "system"),
+                    evt.CreatorId == _currentRequestMetadataInfoProvider.GetCurrentUserName()),
                 A<RequestContext>._,
                 A<Dictionary<string, object>>._,
                 A<bool>._,

--- a/tests/Agenda.Objects.UnitTests/UsernameShould.cs
+++ b/tests/Agenda.Objects.UnitTests/UsernameShould.cs
@@ -1,0 +1,41 @@
+using FsCheck;
+using FsCheck.Xunit;
+using AwesomeAssertions;
+using Xunit.OpenCategories.V3;
+using Xunit;
+using System;
+
+namespace Agenda.Objects.UnitTests;
+
+ [UnitTest]
+public class UsernameShould
+{
+    [Property]
+    public void Create_username_when_input_is_valid(NonWhiteSpaceString validUsernameGenerator)
+    {
+        // Arrange
+        string validUsername = validUsernameGenerator.Get;
+
+        // Act
+        Username username = Username.FromString(validUsername);
+
+        // Assert
+        username.Value.Should().Be(validUsername);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Throw_ArgumentException_when_input_is_invalid(string invalidUsername)
+    {
+
+        // Act 
+        Action buildingUsernameFromInvalidInput = () => _ = Username.FromString(invalidUsername);
+
+        // Assert
+        buildingUsernameFromInvalidInput.Should().Throw<ArgumentException>()
+            .WithMessage("Username cannot be null or whitespace*")
+            .And.ParamName.Should().Be("username");
+    }
+}


### PR DESCRIPTION
Enhance appointment creation by propagating the creator's username. Update dependencies to enable transitive pinning and document these changes in the changelog.